### PR TITLE
Allow SELECT statements to contain multiple values

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/vegarsti/sql/token"
 )
@@ -22,17 +23,21 @@ type Expression interface {
 }
 
 type SelectStatement struct {
-	Token      token.Token // the SELECT token
-	Expression Expression
+	Token       token.Token // the SELECT token
+	Expressions []Expression
 }
 
 func (es *SelectStatement) statementNode()       {}
 func (es *SelectStatement) TokenLiteral() string { return es.Token.Literal }
 func (es *SelectStatement) String() string {
-	if es.Expression != nil {
-		return es.TokenLiteral() + " " + es.Expression.String()
+	if len(es.Expressions) == 0 {
+		return ""
 	}
-	return ""
+	expressions := make([]string, len(es.Expressions))
+	for i, expr := range es.Expressions {
+		expressions[i] = expr.String()
+	}
+	return es.TokenLiteral() + " " + strings.Join(expressions, ", ")
 }
 
 type Program struct {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -12,7 +12,7 @@ func Eval(node ast.Node) object.Object {
 	case *ast.Program:
 		return evalStatements(node.Statements)
 	case *ast.SelectStatement:
-		return Eval(node.Expression)
+		return evalSelectStatement(node.Expressions)
 	case *ast.PrefixExpression:
 		right := Eval(node.Right)
 		if isError(right) {
@@ -55,6 +55,16 @@ func evalStatements(stmts []ast.Statement) object.Object {
 		}
 	}
 	return result
+}
+
+func evalSelectStatement(expressions []ast.Expression) object.Object {
+	row := &object.Row{
+		Values: make([]object.Object, len(expressions)),
+	}
+	for i, e := range expressions {
+		row.Values[i] = Eval(e)
+	}
+	return row
 }
 
 func evalPrefixExpression(operator string, right object.Object) object.Object {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -33,7 +33,14 @@ func TestEvalIntegerExpression(t *testing.T) {
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)
-		testIntegerObject(t, evaluated, tt.expected)
+		row, ok := evaluated.(*object.Row)
+		if !ok {
+			t.Fatalf("object is not Row. got=%T", row)
+		}
+		if len(row.Values) != 1 {
+			t.Fatalf("expected row to contain 1 element. got=%d", len(row.Values))
+		}
+		testIntegerObject(t, row.Values[0], tt.expected)
 	}
 }
 
@@ -72,7 +79,14 @@ func TestEvalFloatExpression(t *testing.T) {
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)
-		testFloatObject(t, evaluated, tt.expected)
+		row, ok := evaluated.(*object.Row)
+		if !ok {
+			t.Fatalf("object is not Row. got=%T", row)
+		}
+		if len(row.Values) != 1 {
+			t.Fatalf("expected row to contain 1 element. got=%d", len(row.Values))
+		}
+		testFloatObject(t, row.Values[0], tt.expected)
 	}
 }
 
@@ -101,7 +115,14 @@ func TestEvalStringExpression(t *testing.T) {
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)
-		testStringObject(t, evaluated, tt.expected)
+		row, ok := evaluated.(*object.Row)
+		if !ok {
+			t.Fatalf("object is not Row. got=%T", row)
+		}
+		if len(row.Values) != 1 {
+			t.Fatalf("expected row to contain 1 element. got=%d", len(row.Values))
+		}
+		testStringObject(t, row.Values[0], tt.expected)
 	}
 }
 
@@ -127,7 +148,14 @@ func TestEvalIdentifierExpression(t *testing.T) {
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)
-		testError(t, evaluated, tt.expectedErrorMessage)
+		row, ok := evaluated.(*object.Row)
+		if !ok {
+			t.Fatalf("object is not Row. got=%T", row)
+		}
+		if len(row.Values) != 1 {
+			t.Fatalf("expected row to contain 1 element. got=%d", len(row.Values))
+		}
+		testError(t, row.Values[0], tt.expectedErrorMessage)
 	}
 }
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -47,6 +47,8 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.LPAREN, l.ch)
 	case ')':
 		tok = newToken(token.RPAREN, l.ch)
+	case ',':
+		tok = newToken(token.COMMA, l.ch)
 	case []byte("'")[0]:
 		tok := l.readString()
 		return tok

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExpressionValue(t *testing.T) {
-	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord"
+	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord ,"
 	tests := []struct {
 		expectedType    token.TokenType
 		expectedLiteral string
@@ -34,6 +34,7 @@ func TestExpressionValue(t *testing.T) {
 		{token.SELECT, "SELECT"},
 		{token.SELECT, "SELECT"},
 		{token.IDENTIFIER, "aWord"},
+		{token.COMMA, ","},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/object/object.go
+++ b/object/object.go
@@ -2,11 +2,13 @@ package object
 
 import (
 	"fmt"
+	"strings"
 )
 
 type ObjectType string
 
 const (
+	ROW_OBJ     = "ROW"
 	INTEGER_OBJ = "INTEGER"
 	FLOAT_OBJ   = "FLOAT"
 	STRING_OBJ  = "STRING"
@@ -17,6 +19,19 @@ type Object interface {
 	Type() ObjectType
 	Inspect() string
 }
+
+type Row struct {
+	Values []Object
+}
+
+func (r *Row) Inspect() string {
+	values := make([]string, len(r.Values))
+	for i, v := range r.Values {
+		values[i] = v.Inspect()
+	}
+	return strings.Join(values, ", ")
+}
+func (r *Row) Type() ObjectType { return ROW_OBJ }
 
 type Integer struct {
 	Value int64

--- a/object/object.go
+++ b/object/object.go
@@ -29,7 +29,7 @@ func (r *Row) Inspect() string {
 	for i, v := range r.Values {
 		values[i] = v.Inspect()
 	}
-	return strings.Join(values, ", ")
+	return strings.Join(values, "\t")
 }
 func (r *Row) Type() ObjectType { return ROW_OBJ }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -162,9 +162,17 @@ func (p *Parser) parseStatement() ast.Statement {
 }
 
 func (p *Parser) parseSelectStatement() *ast.SelectStatement {
-	stmt := &ast.SelectStatement{Token: p.curToken}
+	stmt := &ast.SelectStatement{Token: p.curToken, Expressions: make([]ast.Expression, 0)}
 	p.nextToken() // read SELECT token
-	stmt.Expression = p.parseExpression(LOWEST)
+
+	stmt.Expressions = append(stmt.Expressions, p.parseExpression(LOWEST))
+	p.nextToken()
+	for p.curToken.Type == token.COMMA {
+		p.nextToken() // read comma
+		stmt.Expressions = append(stmt.Expressions, p.parseExpression(LOWEST))
+		p.nextToken() // advance to next token
+	}
+
 	return stmt
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -31,4 +31,5 @@ const (
 	RPAREN = ")"
 	DOT    = "."
 	QUOTE  = "'"
+	COMMA  = ","
 )


### PR DESCRIPTION
Do this by parsing a select statement into a slice of expressions, and it evaluates to a row object.