### PR TITLE
Add support for CREATE TABLE

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -25,7 +25,7 @@ type Expression interface {
 type SelectStatement struct {
 	Token       token.Token // the SELECT token
 	Expressions []Expression
-	Names       []string
+	Aliases     []string // SELECT value AS some_alias
 }
 
 func (es *SelectStatement) statementNode()       {}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -41,6 +41,27 @@ func (es *SelectStatement) String() string {
 	return es.TokenLiteral() + " " + strings.Join(expressions, ", ")
 }
 
+type CreateTableStatement struct {
+	Token   token.Token // the CREATE token
+	Name    string
+	Columns map[string]token.Token
+}
+
+func (cts *CreateTableStatement) statementNode()       {}
+func (cts *CreateTableStatement) TokenLiteral() string { return cts.Token.Literal }
+func (cts *CreateTableStatement) String() string {
+	if len(cts.Columns) == 0 {
+		return ""
+	}
+	columns := make([]string, len(cts.Columns))
+	i := 0
+	for name, tok := range cts.Columns {
+		columns[i] = name + " " + tok.Literal
+		i++
+	}
+	return "CREATE TABLE " + cts.Name + " " + "(" + strings.Join(columns, ", ") + ")"
+}
+
 type Program struct {
 	Statements []Statement
 }

--- a/cmd/sql/main.go
+++ b/cmd/sql/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vegarsti/sql/evaluator"
 	"github.com/vegarsti/sql/lexer"
+	"github.com/vegarsti/sql/object"
 	"github.com/vegarsti/sql/parser"
 )
 
@@ -17,6 +18,8 @@ const PROMPT = ">> "
 func Start(in io.Reader, out io.Writer) {
 	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
 	scanner := bufio.NewScanner(in)
+
+	backend := NewBackend()
 
 	for {
 		fmt.Print(PROMPT)
@@ -35,7 +38,7 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		evaluated := evaluator.Eval(program)
+		evaluated := evaluator.Eval(backend, program)
 		if evaluated != nil {
 			w.Write([]byte(evaluated.Inspect()))
 			w.Write([]byte("\n"))
@@ -52,4 +55,15 @@ func printParserErrors(out io.Writer, errors []string) {
 
 func main() {
 	Start(os.Stdin, os.Stdout)
+}
+
+type Backend struct {
+}
+
+func (tb *Backend) CreateTable(name string, columns []object.Column) error {
+	return fmt.Errorf("no support for tables yet")
+}
+
+func NewBackend() *Backend {
+	return &Backend{}
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -12,7 +12,7 @@ func Eval(node ast.Node) object.Object {
 	case *ast.Program:
 		return evalStatements(node.Statements)
 	case *ast.SelectStatement:
-		return evalSelectStatement(node.Expressions, node.Names)
+		return evalSelectStatement(node.Expressions, node.Aliases)
 	case *ast.CreateTableStatement:
 		return evalCreateTableStatement(node)
 	case *ast.PrefixExpression:
@@ -59,14 +59,14 @@ func evalStatements(stmts []ast.Statement) object.Object {
 	return result
 }
 
-func evalSelectStatement(expressions []ast.Expression, names []string) object.Object {
+func evalSelectStatement(expressions []ast.Expression, aliases []string) object.Object {
 	row := &object.Row{
-		Names:  names,
-		Values: make([]object.Object, len(expressions)),
+		Aliases: aliases,
+		Values:  make([]object.Object, len(expressions)),
 	}
-	for i, n := range names {
+	for i, n := range aliases {
 		if n == "" {
-			names[i] = "?column?"
+			aliases[i] = "?column?"
 		}
 	}
 	for i, e := range expressions {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -13,6 +13,8 @@ func Eval(node ast.Node) object.Object {
 		return evalStatements(node.Statements)
 	case *ast.SelectStatement:
 		return evalSelectStatement(node.Expressions, node.Names)
+	case *ast.CreateTableStatement:
+		return evalCreateTableStatement(node)
 	case *ast.PrefixExpression:
 		right := Eval(node.Right)
 		if isError(right) {
@@ -74,6 +76,10 @@ func evalSelectStatement(expressions []ast.Expression, names []string) object.Ob
 		}
 	}
 	return row
+}
+
+func evalCreateTableStatement(cst *ast.CreateTableStatement) object.Object {
+	return nil
 }
 
 func evalPrefixExpression(operator string, right object.Object) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -93,7 +93,7 @@ func evalCreateTableStatement(backend Backend, cst *ast.CreateTableStatement) ob
 		i++
 	}
 	if err := backend.CreateTable(cst.Name, columns); err != nil {
-		return newError(fmt.Errorf("create table: %w", err).Error())
+		return newError(err.Error())
 	}
 	return &object.OK{}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -209,3 +209,30 @@ func TestEvalSelectMultiple(t *testing.T) {
 		}
 	}
 }
+
+func TestEvalCreateTable(t *testing.T) {
+	tests := []struct {
+		input         string
+		tableName     string
+		expectedTable object.Table
+	}{
+		{
+			"create table foo (a text, b integer, c double)",
+			"foo",
+			object.Table{
+				Name: "foo",
+				Columns: []object.Column{
+					{Name: "a", Type: object.TEXT},
+					{Name: "b", Type: object.INTEGER},
+					{Name: "c", Type: object.DOUBLE},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		if errorObject, ok := evaluated.(*object.Error); ok {
+			t.Fatalf("returned object is Error: %v", errorObject)
+		}
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -187,8 +187,8 @@ func TestEvalSelectMultiple(t *testing.T) {
 		if len(row.Values) != 4 {
 			t.Fatalf("expected row.Values to contain 4 elements. got=%d", len(row.Values))
 		}
-		if len(row.Names) != 4 {
-			t.Fatalf("expected row.Names to have 4 elements. got=%d", len(row.Names))
+		if len(row.Aliases) != 4 {
+			t.Fatalf("expected row.Names to have 4 elements. got=%d", len(row.Aliases))
 		}
 
 		// assert values
@@ -203,7 +203,7 @@ func TestEvalSelectMultiple(t *testing.T) {
 
 		// assert names
 		expectedRowNames := strings.Join(tt.expectedNames, ", ")
-		rowNames := strings.Join(row.Names, ", ")
+		rowNames := strings.Join(row.Aliases, ", ")
 		if rowNames != expectedRowNames {
 			t.Fatalf("expected row names to be [%s], but was [%s]", expectedRowNames, rowNames)
 		}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1,6 +1,7 @@
 package evaluator_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -215,6 +216,9 @@ type testBackend struct {
 }
 
 func (tb *testBackend) CreateTable(name string, columns []object.Column) error {
+	if _, ok := tb.tables[name]; ok {
+		return fmt.Errorf(`relation "%s" already exists`, name)
+	}
 	tb.tables[name] = columns
 	return nil
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -175,7 +175,8 @@ func TestEvalSelectMultiple(t *testing.T) {
 		{
 			"select 'abc', 1 as n, 3.14 as pi, -1",
 			[]interface{}{"abc", int64(1), float64(3.14), int64(-1)},
-			[]string{"?column?", "n", "pi", "?column?"}},
+			[]string{"?column?", "n", "pi", "?column?"},
+		},
 	}
 	for _, tt := range tests {
 		evaluated := testEval(tt.input)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -73,6 +73,15 @@ func (l *Lexer) NextToken() token.Token {
 			if strings.ToUpper(tok.Literal) == token.TABLE {
 				return token.Token{Type: token.TABLE, Literal: token.TABLE}
 			}
+			if strings.ToUpper(tok.Literal) == token.TEXT {
+				return token.Token{Type: token.TEXT, Literal: token.TEXT}
+			}
+			if strings.ToUpper(tok.Literal) == token.DOUBLE {
+				return token.Token{Type: token.DOUBLE, Literal: token.DOUBLE}
+			}
+			if strings.ToUpper(tok.Literal) == token.INTEGER {
+				return token.Token{Type: token.INTEGER, Literal: token.INTEGER}
+			}
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -67,6 +67,12 @@ func (l *Lexer) NextToken() token.Token {
 			if strings.ToUpper(tok.Literal) == token.AS {
 				return token.Token{Type: token.AS, Literal: token.AS}
 			}
+			if strings.ToUpper(tok.Literal) == token.CREATE {
+				return token.Token{Type: token.CREATE, Literal: token.CREATE}
+			}
+			if strings.ToUpper(tok.Literal) == token.TABLE {
+				return token.Token{Type: token.TABLE, Literal: token.TABLE}
+			}
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExpressionValue(t *testing.T) {
-	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table"
+	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer"
 	tests := []struct {
 		expectedType    token.TokenType
 		expectedLiteral string
@@ -41,6 +41,9 @@ func TestExpressionValue(t *testing.T) {
 		{token.AS, "AS"},
 		{token.CREATE, "CREATE"},
 		{token.TABLE, "TABLE"},
+		{token.TEXT, "TEXT"},
+		{token.DOUBLE, "DOUBLE"},
+		{token.INTEGER, "INTEGER"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExpressionValue(t *testing.T) {
-	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As"
+	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table"
 	tests := []struct {
 		expectedType    token.TokenType
 		expectedLiteral string
@@ -39,6 +39,8 @@ func TestExpressionValue(t *testing.T) {
 		{token.AS, "AS"},
 		{token.AS, "AS"},
 		{token.AS, "AS"},
+		{token.CREATE, "CREATE"},
+		{token.TABLE, "TABLE"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/object/object.go
+++ b/object/object.go
@@ -21,8 +21,8 @@ type Object interface {
 }
 
 type Row struct {
-	Names  []string
-	Values []Object
+	Aliases []string
+	Values  []Object
 }
 
 func (r *Row) Inspect() string {
@@ -31,7 +31,7 @@ func (r *Row) Inspect() string {
 		values[i] = v.Inspect()
 	}
 	return strings.Join([]string{
-		strings.Join(r.Names, "\t"),
+		strings.Join(r.Aliases, "\t"),
 		strings.Join(values, "\t"),
 	}, "\n")
 }

--- a/object/object.go
+++ b/object/object.go
@@ -37,6 +37,24 @@ func (r *Row) Inspect() string {
 }
 func (r *Row) Type() ObjectType { return ROW_OBJ }
 
+type DataType string
+
+const (
+	TEXT    = "TEXT"
+	INTEGER = "INTEGER"
+	DOUBLE  = "DOUBLE"
+)
+
+type Table struct {
+	Name    string
+	Columns []Column
+}
+
+type Column struct {
+	Name string
+	Type DataType
+}
+
 type Integer struct {
 	Value int64
 }

--- a/object/object.go
+++ b/object/object.go
@@ -13,6 +13,7 @@ const (
 	FLOAT_OBJ   = "FLOAT"
 	STRING_OBJ  = "STRING"
 	ERROR_OBJ   = "ERROR"
+	OK_OBJ      = "OK"
 )
 
 type Object interface {
@@ -82,3 +83,9 @@ type Error struct {
 
 func (e *Error) Type() ObjectType { return ERROR_OBJ }
 func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
+
+type OK struct {
+}
+
+func (ok *OK) Type() ObjectType { return OK_OBJ }
+func (ok *OK) Inspect() string  { return "OK" }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -322,7 +322,7 @@ func (p *Parser) Errors() []string {
 }
 
 func (p *Parser) peekError(t token.TokenType) {
-	msg := fmt.Sprintf("expected next token to be %s, got %T %s instead",
+	msg := fmt.Sprintf("expected next token to be %s, got %s '%s' instead",
 		t, p.peekToken.Type, p.peekToken.Literal)
 	p.errors = append(p.errors, msg)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -167,7 +167,7 @@ func (p *Parser) parseSelectStatement() *ast.SelectStatement {
 	stmt := &ast.SelectStatement{
 		Token:       p.curToken,
 		Expressions: make([]ast.Expression, 0),
-		Names:       make([]string, 0),
+		Aliases:     make([]string, 0),
 	}
 	p.nextToken() // read SELECT token
 
@@ -183,11 +183,11 @@ func (p *Parser) parseSelectStatement() *ast.SelectStatement {
 			p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %s token with literal %s", p.curToken.Type, p.curToken.Literal))
 			return nil
 		}
-		stmt.Names = append(stmt.Names, p.curToken.Literal)
+		stmt.Aliases = append(stmt.Aliases, p.curToken.Literal)
 
 		p.nextToken()
 	} else {
-		stmt.Names = append(stmt.Names, "")
+		stmt.Aliases = append(stmt.Aliases, "")
 	}
 
 	for p.curToken.Type == token.COMMA {
@@ -197,7 +197,7 @@ func (p *Parser) parseSelectStatement() *ast.SelectStatement {
 
 		// check for AS
 		if p.curToken.Type != token.AS {
-			stmt.Names = append(stmt.Names, "")
+			stmt.Aliases = append(stmt.Aliases, "")
 			continue
 		}
 		p.nextToken() // read AS
@@ -207,7 +207,7 @@ func (p *Parser) parseSelectStatement() *ast.SelectStatement {
 			p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %s token with literal %s", p.curToken.Type, p.curToken.Literal))
 			return nil
 		}
-		stmt.Names = append(stmt.Names, p.curToken.Literal)
+		stmt.Aliases = append(stmt.Aliases, p.curToken.Literal)
 
 		p.nextToken() // advance to next token
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -227,7 +227,7 @@ func (p *Parser) parseCreateTableStatement() *ast.CreateTableStatement {
 
 	// assert next token is an identifier
 	if p.peekToken.Type != token.IDENTIFIER {
-		p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %s token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+		p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
 		return nil
 	}
 	p.nextToken()
@@ -238,10 +238,9 @@ func (p *Parser) parseCreateTableStatement() *ast.CreateTableStatement {
 	}
 
 	// parse column pairs
-
 	// assert next token is a column identifier
 	if p.peekToken.Type != token.IDENTIFIER {
-		p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %s token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+		p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
 		return nil
 	}
 	p.nextToken()
@@ -249,11 +248,30 @@ func (p *Parser) parseCreateTableStatement() *ast.CreateTableStatement {
 
 	// assert next token is a column type
 	if !(p.peekToken.Type == token.TEXT || p.peekToken.Type == token.DOUBLE || p.peekToken.Type == token.INTEGER) {
-		p.errors = append(p.errors, fmt.Sprintf("expected type, got %s token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+		p.errors = append(p.errors, fmt.Sprintf("expected type, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
 		return nil
 	}
 	p.nextToken()
 	stmt.Columns[columnLiteral] = p.curToken
+
+	for p.peekToken.Type == token.COMMA {
+		p.nextToken()
+		// assert next token is a column identifier
+		if p.peekToken.Type != token.IDENTIFIER {
+			p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+			return nil
+		}
+		p.nextToken()
+		columnLiteral := p.curToken.Literal
+
+		// assert next token is a column type
+		if !(p.peekToken.Type == token.TEXT || p.peekToken.Type == token.DOUBLE || p.peekToken.Type == token.INTEGER) {
+			p.errors = append(p.errors, fmt.Sprintf("expected type, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+			return nil
+		}
+		p.nextToken()
+		stmt.Columns[columnLiteral] = p.curToken
+	}
 
 	if !p.expectPeek(token.RPAREN) {
 		return nil
@@ -304,7 +322,7 @@ func (p *Parser) Errors() []string {
 }
 
 func (p *Parser) peekError(t token.TokenType) {
-	msg := fmt.Sprintf("expected next token to be %s, got %s %s instead",
+	msg := fmt.Sprintf("expected next token to be %s, got %T %s instead",
 		t, p.peekToken.Type, p.peekToken.Literal)
 	p.errors = append(p.errors, msg)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -399,8 +399,8 @@ func TestSelectWithAs(t *testing.T) {
 		t.Fatalf("stmt does not contain %d expressions. got=%d", 4, len(stmt.Expressions))
 	}
 
-	if len(stmt.Names) != 4 {
-		t.Fatalf("stmt does not contain %d names. got=%d", 4, len(stmt.Names))
+	if len(stmt.Aliases) != 4 {
+		t.Fatalf("stmt does not contain %d names. got=%d", 4, len(stmt.Aliases))
 	}
 
 	literal1, ok := stmt.Expressions[0].(*ast.IntegerLiteral)
@@ -412,8 +412,8 @@ func TestSelectWithAs(t *testing.T) {
 		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral1, literal1.TokenLiteral())
 	}
 	expectedName1 := ""
-	if stmt.Names[0] != expectedName1 {
-		t.Errorf("name not %s. got=%s", expectedName1, stmt.Names[0])
+	if stmt.Aliases[0] != expectedName1 {
+		t.Errorf("name not %s. got=%s", expectedName1, stmt.Aliases[0])
 	}
 
 	literal2, ok := stmt.Expressions[1].(*ast.IntegerLiteral)
@@ -425,8 +425,8 @@ func TestSelectWithAs(t *testing.T) {
 		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral2, literal2.TokenLiteral())
 	}
 	expectedName2 := "n"
-	if stmt.Names[1] != expectedName2 {
-		t.Errorf("name not %s. got=%s", expectedName2, stmt.Names[1])
+	if stmt.Aliases[1] != expectedName2 {
+		t.Errorf("name not %s. got=%s", expectedName2, stmt.Aliases[1])
 	}
 
 	literal3, ok := stmt.Expressions[2].(*ast.StringLiteral)
@@ -438,8 +438,8 @@ func TestSelectWithAs(t *testing.T) {
 		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral3, literal3.TokenLiteral())
 	}
 	expectedName3 := "str"
-	if stmt.Names[2] != expectedName3 {
-		t.Errorf("name not %s. got=%s", expectedName3, stmt.Names[2])
+	if stmt.Aliases[2] != expectedName3 {
+		t.Errorf("name not %s. got=%s", expectedName3, stmt.Aliases[2])
 	}
 
 	literal4, ok := stmt.Expressions[3].(*ast.IntegerLiteral)
@@ -451,8 +451,8 @@ func TestSelectWithAs(t *testing.T) {
 		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral4, literal4.TokenLiteral())
 	}
 	expectedName4 := ""
-	if stmt.Names[3] != expectedName1 {
-		t.Errorf("name not %s. got=%s", expectedName4, stmt.Names[3])
+	if stmt.Aliases[3] != expectedName1 {
+		t.Errorf("name not %s. got=%s", expectedName4, stmt.Aliases[3])
 	}
 
 	checkParserErrors(t, p)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -456,3 +456,33 @@ func TestSelectWithAs(t *testing.T) {
 
 	checkParserErrors(t, p)
 }
+
+func TestCreateTable(t *testing.T) {
+	input := "create table foo (a text)"
+	l := lexer.New(input)
+	p := parser.New(l)
+
+	program := p.ParseProgram()
+	if program == nil {
+		t.Fatalf("ParseProgram() returned nil")
+	}
+
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain 1 statements. got=%d", len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.CreateTableStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.CreateTableStatement. got=%T", program.Statements[0])
+	}
+
+	if stmt == nil {
+		t.Fatalf("ast.CreateTableStatement is nil")
+	}
+
+	if len(stmt.Columns) != 1 {
+		t.Fatalf("stmt does not contain %d column. got=%d", 1, len(stmt.Columns))
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vegarsti/sql/ast"
 	"github.com/vegarsti/sql/lexer"
 	"github.com/vegarsti/sql/parser"
+	"github.com/vegarsti/sql/token"
 )
 
 func TestIntegerLiteralExpression(t *testing.T) {
@@ -458,7 +459,7 @@ func TestSelectWithAs(t *testing.T) {
 }
 
 func TestCreateTable(t *testing.T) {
-	input := "create table foo (a text)"
+	input := "create table foo (a text, b integer, c double)"
 	l := lexer.New(input)
 	p := parser.New(l)
 
@@ -482,7 +483,26 @@ func TestCreateTable(t *testing.T) {
 		t.Fatalf("ast.CreateTableStatement is nil")
 	}
 
-	if len(stmt.Columns) != 1 {
-		t.Fatalf("stmt does not contain %d column. got=%d", 1, len(stmt.Columns))
+	expectedColumns := map[string]token.Token{
+		"a": {Type: token.TEXT, Literal: token.TEXT},
+		"b": {Type: token.INTEGER, Literal: token.INTEGER},
+		"c": {Type: token.DOUBLE, Literal: token.DOUBLE},
+	}
+
+	if len(stmt.Columns) != len(expectedColumns) {
+		t.Fatalf("stmt does not contain %d columns. got=%d", len(stmt.Columns), len(expectedColumns))
+	}
+
+	for name, expectedToken := range expectedColumns {
+		column, ok := stmt.Columns[name]
+		if !ok {
+			t.Fatalf("stmt does not contain column %s", name)
+		}
+		if column.Literal != expectedToken.Literal {
+			t.Fatalf("expected token literal %s for column %s. got=%s", expectedToken.Literal, name, column.Literal)
+		}
+		if stmt.Columns[name].Type != expectedToken.Type {
+			t.Fatalf("expected token type %T for column %s. got=%T", expectedToken.Type, name, column.Type)
+		}
 	}
 }

--- a/token/token.go
+++ b/token/token.go
@@ -26,6 +26,8 @@ const (
 	// Keywords
 	SELECT = "SELECT"
 	AS     = "AS"
+	CREATE = "CREATE"
+	TABLE  = "TABLE"
 
 	// Delimiters
 	LPAREN = "("

--- a/token/token.go
+++ b/token/token.go
@@ -29,6 +29,11 @@ const (
 	CREATE = "CREATE"
 	TABLE  = "TABLE"
 
+	// Types
+	TEXT    = "TEXT"
+	DOUBLE  = "DOUBLE"
+	INTEGER = "INTEGER"
+
 	// Delimiters
 	LPAREN = "("
 	RPAREN = ")"


### PR DESCRIPTION
Lex, parse and evaluate `CREATE TABLE` statements with types `text`, `double` and `integer`. The actual creation of a table must be handled by a struct that implements the `eval.Backend` interface.