### PR TITLE
SELECT FROM table

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -26,6 +26,7 @@ type SelectStatement struct {
 	Token       token.Token // the SELECT token
 	Expressions []Expression
 	Aliases     []string // SELECT value AS some_alias
+	From        string
 }
 
 func (es *SelectStatement) statementNode()       {}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -125,7 +125,7 @@ type StringLiteral struct {
 
 func (sl *StringLiteral) expressionNode()      {}
 func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
-func (sl *StringLiteral) String() string       { return sl.Token.Literal }
+func (sl *StringLiteral) String() string       { return "'" + sl.Token.Literal + "'" }
 
 type Identifier struct {
 	Token token.Token

--- a/cmd/sql/main.go
+++ b/cmd/sql/main.go
@@ -19,7 +19,7 @@ func Start(in io.Reader, out io.Writer) {
 	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
 	scanner := bufio.NewScanner(in)
 
-	backend := NewBackend()
+	backend := newTestBackend()
 
 	for {
 		fmt.Print(PROMPT)
@@ -57,21 +57,46 @@ func main() {
 	Start(os.Stdin, os.Stdout)
 }
 
-type Backend struct {
+type testBackend struct {
+	tables map[string][]object.Column
+	rows   map[string][]object.Row
 }
 
-func (tb *Backend) CreateTable(name string, columns []object.Column) error {
-	return fmt.Errorf("no support for tables yet")
+func (tb *testBackend) CreateTable(name string, columns []object.Column) error {
+	if _, ok := tb.tables[name]; ok {
+		return fmt.Errorf(`relation "%s" already exists`, name)
+	}
+	tb.tables[name] = columns
+	tb.rows[name] = make([]object.Row, 0)
+	return nil
 }
 
-func (tb *Backend) InsertInto(name string, row object.Row) error {
-	return fmt.Errorf("no support for tables yet")
+func (tb *testBackend) InsertInto(name string, row object.Row) error {
+	if _, ok := tb.tables[name]; !ok {
+		return fmt.Errorf(`relation "%s" does not exist`, name)
+	}
+	tb.rows[name] = append(tb.rows[name], row)
+	// Populate aliases
+	for i := range tb.rows[name] {
+		tb.rows[name][i].Aliases = make([]string, len(tb.tables[name]))
+		for j, column := range tb.tables[name] {
+			tb.rows[name][i].Aliases[j] = column.Name
+		}
+	}
+	return nil
 }
 
-func (tb *Backend) Rows(name string) ([]object.Row, error) {
-	return nil, fmt.Errorf("no support for tables yet")
+func (tb *testBackend) Rows(name string) ([]object.Row, error) {
+	rows, ok := tb.rows[name]
+	if !ok {
+		return nil, fmt.Errorf(`relation "%s" does not exist`, name)
+	}
+	return rows, nil
 }
 
-func NewBackend() *Backend {
-	return &Backend{}
+func newTestBackend() *testBackend {
+	return &testBackend{
+		tables: make(map[string][]object.Column),
+		rows:   make(map[string][]object.Row),
+	}
 }

--- a/cmd/sql/main.go
+++ b/cmd/sql/main.go
@@ -68,7 +68,7 @@ func (tb *Backend) InsertInto(name string, row object.Row) error {
 	return fmt.Errorf("no support for tables yet")
 }
 
-func (tb *Backend) Rows(name string, columnNames []string) ([]object.Row, error) {
+func (tb *Backend) Rows(name string) ([]object.Row, error) {
 	return nil, fmt.Errorf("no support for tables yet")
 }
 

--- a/cmd/sql/main.go
+++ b/cmd/sql/main.go
@@ -68,6 +68,10 @@ func (tb *Backend) InsertInto(name string, row object.Row) error {
 	return fmt.Errorf("no support for tables yet")
 }
 
+func (tb *Backend) Rows(name string, columnNames []string) ([]object.Row, error) {
+	return nil, fmt.Errorf("no support for tables yet")
+}
+
 func NewBackend() *Backend {
 	return &Backend{}
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -10,7 +10,7 @@ import (
 type Backend interface {
 	CreateTable(string, []object.Column) error
 	InsertInto(string, object.Row) error
-	Rows(string, []string) ([]object.Row, error) // the table to fetch rows from, and the subset of rows
+	Rows(string) ([]object.Row, error) // the table to fetch rows from, and the subset of rows
 }
 
 func Eval(backend Backend, node ast.Node) object.Object {
@@ -94,13 +94,7 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 	var rows []object.Row
 	var err error
 	if ss.From != "" {
-		columnsToFetch := make([]string, 0)
-		for _, e := range ss.Expressions {
-			if identifier, ok := e.(*ast.Identifier); ok {
-				columnsToFetch = append(columnsToFetch, identifier.String())
-			}
-		}
-		rows, err = backend.Rows(ss.From, columnsToFetch)
+		rows, err = backend.Rows(ss.From)
 		if err != nil {
 			return newError(err.Error())
 		}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -10,7 +10,7 @@ import (
 type Backend interface {
 	CreateTable(string, []object.Column) error
 	InsertInto(string, object.Row) error
-	Rows(string) ([]object.Row, error) // the table to fetch rows from, and the subset of rows
+	Rows(string) ([]object.Row, error)
 }
 
 func Eval(backend Backend, node ast.Node) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -105,11 +105,11 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 			return row.Values[i]
 		}
 	}
-	rows := &object.Result{
-		Aliases: aliases,
+	result := &object.Result{
+		Aliases: ss.Aliases,
 		Rows:    []*object.Row{row},
 	}
-	return rows
+	return result
 }
 
 func evalCreateTableStatement(backend Backend, cst *ast.CreateTableStatement) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -104,10 +104,6 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 			Values:  make([]object.Object, len(ss.Expressions)),
 		}
 		for i, e := range ss.Expressions {
-			// Populate aliases if the expression is just a column
-			if columnIdentifier, ok := e.(*ast.Identifier); ok {
-				aliases[i] = columnIdentifier.Value
-			}
 			row.Values[i] = evalExpression(backendRow, e)
 			if isError(row.Values[i]) {
 				return row.Values[i]
@@ -118,7 +114,7 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 	// Populate aliases
 	for i, alias := range ss.Aliases {
 		if alias == "" {
-			aliases[i] = "?column?"
+			aliases[i] = ss.Expressions[i].String()
 		}
 	}
 	result := &object.Result{

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -191,7 +191,7 @@ func TestEvalSelectMultiple(t *testing.T) {
 		{
 			"select 'abc', 1 as n, 3.14 as pi, -1",
 			[]interface{}{"abc", int64(1), float64(3.14), int64(-1)},
-			[]string{"?column?", "n", "pi", "?column?"},
+			[]string{"abc", "n", "pi", "(-1)"},
 		},
 	}
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -252,7 +252,7 @@ func (tb *testBackend) InsertInto(name string, row object.Row) error {
 	return nil
 }
 
-func (tb *testBackend) Rows(name string, columns []string) ([]object.Row, error) {
+func (tb *testBackend) Rows(name string) ([]object.Row, error) {
 	rows, ok := tb.rows[name]
 	if !ok {
 		return nil, fmt.Errorf(`relation "%s" does not exist`, name)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -191,7 +191,7 @@ func TestEvalSelectMultiple(t *testing.T) {
 		{
 			"select 'abc', 1 as n, 3.14 as pi, -1",
 			[]interface{}{"abc", int64(1), float64(3.14), int64(-1)},
-			[]string{"abc", "n", "pi", "(-1)"},
+			[]string{"'abc'", "n", "pi", "(-1)"},
 		},
 	}
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -368,8 +368,9 @@ func TestEvalInsert(t *testing.T) {
 
 func TestEvalSelectFrom(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected [][]string
+		input           string
+		expected        [][]string
+		expectedAliases string
 	}{
 		{
 			"select a, b from foo",
@@ -377,6 +378,7 @@ func TestEvalSelectFrom(t *testing.T) {
 				{"abc", "def"},
 				{"bcd", "efg"},
 			},
+			"a, b",
 		},
 		{
 			"select a from foo",
@@ -384,6 +386,7 @@ func TestEvalSelectFrom(t *testing.T) {
 				{"abc"},
 				{"bcd"},
 			},
+			"a",
 		},
 		{
 			"select b from foo",
@@ -391,6 +394,7 @@ func TestEvalSelectFrom(t *testing.T) {
 				{"def"},
 				{"efg"},
 			},
+			"b",
 		},
 	}
 	for _, tt := range tests {
@@ -438,6 +442,11 @@ func TestEvalSelectFrom(t *testing.T) {
 		}
 		for i := range row2.Values {
 			testStringObject(t, row2.Values[i], tt.expected[1][i])
+		}
+
+		gotAliases := strings.Join(result.Aliases, ", ")
+		if gotAliases != tt.expectedAliases {
+			t.Fatalf("expected aliases %s. got=%s", tt.expectedAliases, gotAliases)
 		}
 	}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -374,6 +374,7 @@ func TestEvalSelectFrom(t *testing.T) {
 				&object.String{Value: "abc"},
 				&object.String{Value: "def"},
 			},
+			Aliases: []string{"a", "b"},
 		}}
 		evaluated := testEval(backend, tt.input)
 		result, ok := evaluated.(*object.Result)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -373,13 +373,17 @@ func TestEvalSelectFrom(t *testing.T) {
 			},
 		}}
 		evaluated := testEval(backend, tt.input)
-		row, ok := evaluated.(*object.Row)
+		result, ok := evaluated.(*object.Result)
 		if !ok {
 			if errorEvaluated, errorOK := evaluated.(*object.Error); errorOK {
 				t.Fatalf("object is Error: %s", errorEvaluated.Inspect())
 			}
-			t.Fatalf("object is not Row. got=%T", evaluated)
+			t.Fatalf("object is not Result. got=%T", evaluated)
 		}
+		if len(result.Rows) != 1 {
+			t.Fatalf("expected result to contain 1 row. got=%d", len(result.Rows))
+		}
+		row := result.Rows[0]
 		if len(row.Values) != len(tt.expected) {
 			t.Fatalf("expected row to contain %d element. got=%d", len(tt.expected), len(row.Values))
 		}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -249,6 +249,13 @@ func (tb *testBackend) InsertInto(name string, row object.Row) error {
 		return fmt.Errorf(`relation "%s" does not exist`, name)
 	}
 	tb.rows[name] = append(tb.rows[name], row)
+	// Populate aliases
+	for i := range tb.rows[name] {
+		tb.rows[name][i].Aliases = make([]string, len(tb.tables[name]))
+		for j, column := range tb.tables[name] {
+			tb.rows[name][i].Aliases[j] = column.Name
+		}
+	}
 	return nil
 }
 
@@ -349,6 +356,11 @@ func TestEvalInsert(t *testing.T) {
 			}
 			if rows[0].Values[i].Inspect() != tt.expectedValues[i].Inspect() {
 				t.Fatalf("expected row[%d] to have %v value. got=%v", i, tt.expectedValues[i].Inspect(), rows[0].Values[i].Inspect())
+			}
+			expectedAliases := "a, b, c"
+			gotAliases := strings.Join(rows[0].Aliases, ", ")
+			if gotAliases != expectedAliases {
+				t.Fatalf("expected aliases to be %s. got=%s", expectedAliases, gotAliases)
 			}
 		}
 	}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -91,6 +91,9 @@ func (l *Lexer) NextToken() token.Token {
 			if strings.ToUpper(tok.Literal) == token.VALUES {
 				return token.Token{Type: token.VALUES, Literal: token.VALUES}
 			}
+			if strings.ToUpper(tok.Literal) == token.FROM {
+				return token.Token{Type: token.FROM, Literal: token.FROM}
+			}
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExpressionValue(t *testing.T) {
-	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values"
+	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values from"
 	tests := []struct {
 		expectedType    token.TokenType
 		expectedLiteral string
@@ -47,6 +47,7 @@ func TestExpressionValue(t *testing.T) {
 		{token.INSERT, "INSERT"},
 		{token.INTO, "INTO"},
 		{token.VALUES, "VALUES"},
+		{token.FROM, "FROM"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/object/object.go
+++ b/object/object.go
@@ -90,7 +90,7 @@ type String struct {
 	Value string
 }
 
-func (s *String) Inspect() string  { return s.Value }
+func (s *String) Inspect() string  { return "'" + s.Value + "'" }
 func (s *String) Type() ObjectType { return STRING_OBJ }
 
 type Error struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -261,7 +261,7 @@ func (p *Parser) parseCreateTableStatement() *ast.CreateTableStatement {
 
 	// assert next token is a column type
 	if !(p.peekToken.Type == token.TEXT || p.peekToken.Type == token.DOUBLE || p.peekToken.Type == token.INTEGER) {
-		p.errors = append(p.errors, fmt.Sprintf("expected type, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+		p.errors = append(p.errors, fmt.Sprintf("expected type, got %s token with literal %s", p.peekToken.Type, p.peekToken.Literal))
 		return nil
 	}
 	p.nextToken()
@@ -279,7 +279,7 @@ func (p *Parser) parseCreateTableStatement() *ast.CreateTableStatement {
 
 		// assert next token is a column type
 		if !(p.peekToken.Type == token.TEXT || p.peekToken.Type == token.DOUBLE || p.peekToken.Type == token.INTEGER) {
-			p.errors = append(p.errors, fmt.Sprintf("expected type, got %T token with literal %s", p.peekToken.Type, p.peekToken.Literal))
+			p.errors = append(p.errors, fmt.Sprintf("expected type, got %s token with literal %s", p.peekToken.Type, p.peekToken.Literal))
 			return nil
 		}
 		p.nextToken()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -214,6 +214,17 @@ func (p *Parser) parseSelectStatement() *ast.SelectStatement {
 		p.nextToken() // advance to next token
 	}
 
+	if p.curToken.Type == token.FROM {
+		p.nextToken()
+		// assert next token is an identifier
+		if p.curToken.Type != token.IDENTIFIER {
+			p.errors = append(p.errors, fmt.Sprintf("expected identifier, got %s token with literal %s", p.curToken.Type, p.curToken.Literal))
+			return nil
+		}
+		stmt.From = p.curToken.Literal
+		p.nextToken()
+	}
+
 	return stmt
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -551,3 +551,43 @@ func TestInsert(t *testing.T) {
 		}
 	}
 }
+
+func TestSelectFrom(t *testing.T) {
+	input := "select a from foo"
+	l := lexer.New(input)
+	p := parser.New(l)
+
+	program := p.ParseProgram()
+	if program == nil {
+		t.Fatalf("ParseProgram() returned nil")
+	}
+
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain 1 statements. got=%d", len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.SelectStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.SelectStatement. got=%T", program.Statements[0])
+	}
+
+	if len(stmt.Expressions) != 1 {
+		t.Fatalf("stmt does not contain %d expressions. got=%d", 1, len(stmt.Expressions))
+	}
+
+	literal, ok := stmt.Expressions[0].(*ast.Identifier)
+	if !ok {
+		t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[0])
+	}
+	expectedLiteral := "a"
+	if literal.TokenLiteral() != expectedLiteral {
+		t.Fatalf("literal.TokenLiteral not %s. got=%s", expectedLiteral, literal.TokenLiteral())
+	}
+
+	expectedFrom := "foo"
+	if stmt.From != expectedFrom {
+		t.Fatalf("stmt.From not %s. got=%s", expectedFrom, stmt.From)
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -31,6 +31,7 @@ const (
 	INSERT = "INSERT"
 	INTO   = "INTO"
 	VALUES = "VALUES"
+	FROM   = "FROM"
 
 	// Types
 	TEXT    = "TEXT"


### PR DESCRIPTION
In this PR we add support for actually selecting from a table. We have support for parsing identifiers, and a dummy evaluation of identifiers. Here we switch to passing a `object.Row` when we evaluate expressions, such as an identifier. Thus we can evaluate the identifier as the value from a column in the row, if present. So we here also change to fetch rows from the backend, and iterate over them, evaluating the expression in an environment consisting of the row, and return the result consisting of all evaluated expressions.

Typically SQL implementations show a name or alias when displaying a select statement. If the user provides an `AS alias`, this is straightforward. But if not, it turned out to be tricker than I had thought. I started out displaying `?column?` for unnamed columns, and the column name for simple column selects. This is what Postgres does. To make sure we use the column name for simple column selects, we need to check if the expression is a simple identifier. This means an interface assertion, which breaks the abstraction of an expression.

It turns out SQLite simply parrots back the expression in the select, e.g.

```
select a, b, 'a', 1 +2 from foo;
a           b           'a'         1 +2
----------  ----------  ----------  ----------
hello       2           a           3
```
note here that the `1 +2` is parroted back, so it doesn't seem to be printing a parsed expression, simply what the user inputs.

This gave me the idea of just letting the column aliases in the output be the stringified version of the parsed expression, i.e.

https://github.com/vegarsti/sql/blob/3ba195098e2ad0ddc24e6b8581f134057200365b/evaluator/evaluator.go#L114-L119

I think this was nicer!