### PR TITLE
Add ORDER BY to SELECTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ OK
 OK
 >> insert into programming_languages values ('Go', 2009)
 OK
->> select name, first_appeared from programming_languages
+>> select name, first_appeared from programming_languages order by first_appeared
 name     first_appeared
+'Lisp'   1958
 'C'      1972
 'Python' 1990
-'Lisp'   1958
 'Go'     2009
 >> select name, 2021 - first_appeared as years_since_introduction from programming_languages
 name     years_since_introduction

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -22,12 +22,17 @@ type Expression interface {
 	expressionNode()
 }
 
+type OrderByExpression struct {
+	Expression Expression
+	Ascending  bool
+}
+
 type SelectStatement struct {
 	Token       token.Token // the SELECT token
 	Expressions []Expression
 	Aliases     []string // SELECT value AS some_alias
 	From        string
-	OrderBy     []Expression // can be any expression that would be valid in the query's select list
+	OrderBy     []OrderByExpression // can be any expression that would be valid in the query's select list
 }
 
 func (es *SelectStatement) statementNode()       {}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -24,7 +24,7 @@ type Expression interface {
 
 type OrderByExpression struct {
 	Expression Expression
-	Ascending  bool
+	Descending bool
 }
 
 type SelectStatement struct {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -27,6 +27,7 @@ type SelectStatement struct {
 	Expressions []Expression
 	Aliases     []string // SELECT value AS some_alias
 	From        string
+	OrderBy     []Expression // can be any expression that would be valid in the query's select list
 }
 
 func (es *SelectStatement) statementNode()       {}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -112,7 +112,7 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 			}
 		}
 		for i, e := range ss.OrderBy {
-			row.SortByValues[i] = evalExpression(backendRow, e)
+			row.SortByValues[i] = evalExpression(backendRow, e.Expression)
 			if isError(row.SortByValues[i]) {
 				return row.SortByValues[i]
 			}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -421,6 +421,14 @@ func TestEvalSelectFrom(t *testing.T) {
 			},
 			"b",
 		},
+		{
+			"select b from foo order by b desc",
+			[][]string{
+				{"efg"},
+				{"def"},
+			},
+			"b",
+		},
 	}
 	for _, tt := range tests {
 		backend := newTestBackend()

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -392,8 +392,8 @@ func TestEvalSelectFrom(t *testing.T) {
 		{
 			"select a, b from foo",
 			[][]string{
-				{"abc", "def"},
-				{"bcd", "efg"},
+				{"abc", "efg"},
+				{"bcd", "def"},
 			},
 			"a, b",
 		},
@@ -408,6 +408,14 @@ func TestEvalSelectFrom(t *testing.T) {
 		{
 			"select b from foo",
 			[][]string{
+				{"efg"},
+				{"def"},
+			},
+			"b",
+		},
+		{
+			"select b from foo order by b",
+			[][]string{
 				{"def"},
 				{"efg"},
 			},
@@ -418,19 +426,22 @@ func TestEvalSelectFrom(t *testing.T) {
 		backend := newTestBackend()
 		backend.tables["foo"] = []object.Column{
 			{Name: "a", Type: object.DataType("TEXT")},
+			{Name: "b", Type: object.DataType("TEXT")},
 		}
 		backend.rows["foo"] = []object.Row{
 			{
 				Values: []object.Object{
 					&object.String{Value: "abc"},
-					&object.String{Value: "def"},
+					&object.String{Value: "efg"},
+					&object.Integer{Value: 1},
 				},
 				Aliases: []string{"a", "b"},
 			},
 			{
 				Values: []object.Object{
 					&object.String{Value: "bcd"},
-					&object.String{Value: "efg"},
+					&object.String{Value: "def"},
+					&object.Integer{Value: 2},
 				},
 				Aliases: []string{"a", "b"},
 			},

--- a/example.sql
+++ b/example.sql
@@ -1,0 +1,5 @@
+create table programming_languages (name text, first_appeared integer);
+insert into programming_languages values ('C', 1972);
+insert into programming_languages values ('Python', 1990);
+insert into programming_languages values ('Lisp', 1958);
+insert into programming_languages values ('Go', 2009);

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -102,6 +102,9 @@ func (l *Lexer) NextToken() token.Token {
 			if strings.ToUpper(tok.Literal) == token.BY {
 				return token.Token{Type: token.BY, Literal: token.BY}
 			}
+			if strings.ToUpper(tok.Literal) == token.DESC {
+				return token.Token{Type: token.DESC, Literal: token.DESC}
+			}
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -96,6 +96,12 @@ func (l *Lexer) NextToken() token.Token {
 			if strings.ToUpper(tok.Literal) == token.FROM {
 				return token.Token{Type: token.FROM, Literal: token.FROM}
 			}
+			if strings.ToUpper(tok.Literal) == token.ORDER {
+				return token.Token{Type: token.ORDER, Literal: token.ORDER}
+			}
+			if strings.ToUpper(tok.Literal) == token.BY {
+				return token.Token{Type: token.BY, Literal: token.BY}
+			}
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestExpressionValue(t *testing.T) {
-	input := "1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values from identifier_with_underscore;"
+	input := `
+1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values from identifier_with_underscore;
+order by
+`
 	tests := []struct {
 		expectedType    token.TokenType
 		expectedLiteral string
@@ -50,6 +53,8 @@ func TestExpressionValue(t *testing.T) {
 		{token.FROM, "FROM"},
 		{token.IDENTIFIER, "identifier_with_underscore"},
 		{token.SEMICOLON, ";"},
+		{token.ORDER, "ORDER"},
+		{token.BY, "BY"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -10,7 +10,7 @@ import (
 func TestExpressionValue(t *testing.T) {
 	input := `
 1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values from identifier_with_underscore;
-order by
+order by desc
 `
 	tests := []struct {
 		expectedType    token.TokenType
@@ -55,6 +55,7 @@ order by
 		{token.SEMICOLON, ";"},
 		{token.ORDER, "ORDER"},
 		{token.BY, "BY"},
+		{token.DESC, "DESC"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/object/object.go
+++ b/object/object.go
@@ -24,10 +24,15 @@ type Object interface {
 	SortValue() float64
 }
 
+type SortBy struct {
+	Value      Object
+	Descending bool
+}
+
 type Row struct {
 	Aliases      []string
 	Values       []Object
-	SortByValues []Object
+	SortByValues []SortBy
 }
 
 func (r *Row) Inspect() string {

--- a/object/object.go
+++ b/object/object.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -20,11 +21,13 @@ const (
 type Object interface {
 	Type() ObjectType
 	Inspect() string
+	SortValue() float64
 }
 
 type Row struct {
-	Aliases []string
-	Values  []Object
+	Aliases      []string
+	Values       []Object
+	SortByValues []Object
 }
 
 func (r *Row) Inspect() string {
@@ -34,7 +37,8 @@ func (r *Row) Inspect() string {
 	}
 	return strings.Join(values, "\t")
 }
-func (r *Row) Type() ObjectType { return ROW_OBJ }
+func (r *Row) Type() ObjectType   { return ROW_OBJ }
+func (r *Row) SortValue() float64 { panic("a row doesn't have a sort value") }
 
 type Result struct {
 	Aliases []string
@@ -52,7 +56,8 @@ func (r *Result) Inspect() string {
 		allRowsString,
 	}, "\n")
 }
-func (r *Result) Type() ObjectType { return RESULT_OBJ }
+func (r *Result) Type() ObjectType   { return RESULT_OBJ }
+func (r *Result) SortValue() float64 { panic("a result doesn't have a sort value") }
 
 type DataType string
 
@@ -76,15 +81,17 @@ type Integer struct {
 	Value int64
 }
 
-func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
-func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
+func (i *Integer) Inspect() string    { return fmt.Sprintf("%d", i.Value) }
+func (i *Integer) Type() ObjectType   { return INTEGER_OBJ }
+func (i *Integer) SortValue() float64 { return float64(i.Value) }
 
 type Float struct {
 	Value float64
 }
 
-func (f *Float) Inspect() string  { return fmt.Sprintf("%f", f.Value) }
-func (f *Float) Type() ObjectType { return FLOAT_OBJ }
+func (f *Float) Inspect() string    { return fmt.Sprintf("%f", f.Value) }
+func (f *Float) Type() ObjectType   { return FLOAT_OBJ }
+func (f *Float) SortValue() float64 { return f.Value }
 
 type String struct {
 	Value string
@@ -93,15 +100,29 @@ type String struct {
 func (s *String) Inspect() string  { return "'" + s.Value + "'" }
 func (s *String) Type() ObjectType { return STRING_OBJ }
 
+// SortValue of a string is u * 10^-i,
+// where u is the unicode value of the rune,
+// and i is the index of the rune in the string
+func (s *String) SortValue() float64 {
+	sortValue := float64(0)
+	for i, r := range s.Value {
+		unicodeValue := int(r)
+		sortValue += float64(unicodeValue) * math.Pow10(-i)
+	}
+	return sortValue
+}
+
 type Error struct {
 	Message string
 }
 
-func (e *Error) Type() ObjectType { return ERROR_OBJ }
-func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
+func (e *Error) Type() ObjectType   { return ERROR_OBJ }
+func (e *Error) Inspect() string    { return "ERROR: " + e.Message }
+func (e *Error) SortValue() float64 { panic("an error doesn't have a sort value") }
 
 type OK struct {
 }
 
-func (ok *OK) Type() ObjectType { return OK_OBJ }
-func (ok *OK) Inspect() string  { return "OK" }
+func (ok *OK) Type() ObjectType   { return OK_OBJ }
+func (ok *OK) Inspect() string    { return "OK" }
+func (ok *OK) SortValue() float64 { panic("an OK doesn't have a sort value") }

--- a/object/object.go
+++ b/object/object.go
@@ -105,9 +105,9 @@ type String struct {
 func (s *String) Inspect() string  { return "'" + s.Value + "'" }
 func (s *String) Type() ObjectType { return STRING_OBJ }
 
-// SortValue of a string is u * 10^-i,
-// where u is the unicode value of the rune,
-// and i is the index of the rune in the string
+// SortValue of a string is the sum of all individual u * 10^-i,
+// where u is the unicode value of each rune,
+// and i is the index of that rune in the string.
 func (s *String) SortValue() float64 {
 	sortValue := float64(0)
 	for i, r := range s.Value {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -239,16 +239,26 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		if sortExpr == nil {
 			return nil
 		}
-		stmt.OrderBy = append(stmt.OrderBy, ast.OrderByExpression{Expression: sortExpr})
+		orderBy := ast.OrderByExpression{Expression: sortExpr}
 		p.nextToken()
+		if p.curToken.Type == token.DESC {
+			orderBy.Descending = true
+			p.nextToken()
+		}
+		stmt.OrderBy = append(stmt.OrderBy, orderBy)
 		for p.curToken.Type == token.COMMA {
 			p.nextToken() // read comma
 			sortExpr = p.parseExpression(LOWEST)
 			if sortExpr == nil {
 				return nil
 			}
-			stmt.OrderBy = append(stmt.OrderBy, ast.OrderByExpression{Expression: sortExpr})
+			orderBy := ast.OrderByExpression{Expression: sortExpr}
 			p.nextToken()
+			if p.curToken.Type == token.DESC {
+				orderBy.Descending = true
+				p.nextToken()
+			}
+			stmt.OrderBy = append(stmt.OrderBy, orderBy)
 		}
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -173,7 +173,7 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		Token:       p.curToken,
 		Expressions: make([]ast.Expression, 0),
 		Aliases:     make([]string, 0),
-		OrderBy:     make([]ast.Expression, 0),
+		OrderBy:     make([]ast.OrderByExpression, 0),
 	}
 	p.nextToken() // read SELECT token
 
@@ -239,7 +239,7 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		if sortExpr == nil {
 			return nil
 		}
-		stmt.OrderBy = append(stmt.OrderBy, sortExpr)
+		stmt.OrderBy = append(stmt.OrderBy, ast.OrderByExpression{Expression: sortExpr})
 		p.nextToken()
 		for p.curToken.Type == token.COMMA {
 			p.nextToken() // read comma
@@ -247,7 +247,7 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 			if sortExpr == nil {
 				return nil
 			}
-			stmt.OrderBy = append(stmt.OrderBy, sortExpr)
+			stmt.OrderBy = append(stmt.OrderBy, ast.OrderByExpression{Expression: sortExpr})
 			p.nextToken()
 		}
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -460,7 +460,7 @@ func TestSelectWithAs(t *testing.T) {
 }
 
 func TestSelectOrderBy(t *testing.T) {
-	input := "select a from foo order by a, b + 1"
+	input := "select a from foo order by a desc, b + 1 desc"
 	l := lexer.New(input)
 	p := parser.New(l)
 
@@ -506,6 +506,9 @@ func TestSelectOrderBy(t *testing.T) {
 	gotOrderByStrings := make([]string, len(stmt.OrderBy))
 	for i, orderBy := range stmt.OrderBy {
 		gotOrderByStrings[i] = orderBy.Expression.String()
+		if !orderBy.Descending {
+			t.Fatalf("expected stmt.OrderBy.Expression.Descending to be true. got false")
+		}
 	}
 	gotOrderByString := strings.Join(gotOrderByStrings, ", ")
 	if gotOrderByString != expectedOrderByString {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -504,8 +504,8 @@ func TestSelectOrderBy(t *testing.T) {
 	}
 	expectedOrderByString := strings.Join(expectedOrderBy, ", ")
 	gotOrderByStrings := make([]string, len(stmt.OrderBy))
-	for i, expr := range stmt.OrderBy {
-		gotOrderByStrings[i] = expr.String()
+	for i, orderBy := range stmt.OrderBy {
+		gotOrderByStrings[i] = orderBy.Expression.String()
 	}
 	gotOrderByString := strings.Join(gotOrderByStrings, ", ")
 	if gotOrderByString != expectedOrderByString {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/vegarsti/sql/ast"
@@ -456,6 +457,60 @@ func TestSelectWithAs(t *testing.T) {
 	}
 
 	checkParserErrors(t, p)
+}
+
+func TestSelectOrderBy(t *testing.T) {
+	input := "select a from foo order by a, b + 1"
+	l := lexer.New(input)
+	p := parser.New(l)
+
+	program := p.ParseProgram()
+	if program == nil {
+		t.Fatalf("ParseProgram() returned nil")
+	}
+
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain 1 statements. got=%d", len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.SelectStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.SelectStatement. got=%T", program.Statements[0])
+	}
+
+	if len(stmt.Expressions) != 1 {
+		t.Fatalf("stmt does not contain %d expressions. got=%d", 1, len(stmt.Expressions))
+	}
+
+	literal, ok := stmt.Expressions[0].(*ast.Identifier)
+	if !ok {
+		t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[0])
+	}
+	expectedLiteral := "a"
+	if literal.TokenLiteral() != expectedLiteral {
+		t.Fatalf("literal.TokenLiteral not %s. got=%s", expectedLiteral, literal.TokenLiteral())
+	}
+
+	expectedFrom := "foo"
+	if stmt.From != expectedFrom {
+		t.Fatalf("stmt.From not %s. got=%s", expectedFrom, stmt.From)
+	}
+
+	expectedOrderBy := []string{"a", "(b + 1)"}
+	if len(stmt.OrderBy) != len(expectedOrderBy) {
+		t.Fatalf("stmt.OrderBy has length %d, expected %d", len(stmt.OrderBy), len(expectedOrderBy))
+	}
+	expectedOrderByString := strings.Join(expectedOrderBy, ", ")
+	gotOrderByStrings := make([]string, len(stmt.OrderBy))
+	for i, expr := range stmt.OrderBy {
+		gotOrderByStrings[i] = expr.String()
+	}
+	gotOrderByString := strings.Join(gotOrderByStrings, ", ")
+	if gotOrderByString != expectedOrderByString {
+		t.Fatalf("expected stmt.OrderBy to be %s. got=%s", expectedOrderByString, gotOrderByString)
+	}
 }
 
 func TestCreateTable(t *testing.T) {

--- a/token/token.go
+++ b/token/token.go
@@ -32,6 +32,8 @@ const (
 	INTO   = "INTO"
 	VALUES = "VALUES"
 	FROM   = "FROM"
+	ORDER  = "ORDER"
+	BY     = "BY"
 
 	// Types
 	TEXT    = "TEXT"

--- a/token/token.go
+++ b/token/token.go
@@ -34,6 +34,7 @@ const (
 	FROM   = "FROM"
 	ORDER  = "ORDER"
 	BY     = "BY"
+	DESC   = "DESC"
 
 	// Types
 	TEXT    = "TEXT"


### PR DESCRIPTION
The `object.Object` interface is becoming too big, and here we add a method to the interface which panics for half of the structs that implement the interface. Need to split it up into two interfaces: A more general `Object` and a `Value` which represents an actual SQL value, like a string, an int or a float.