### PR TITLE
Support join

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ name     first_appeared
 ERROR: unknown operator: INTEGER + STRING
 >> 1
 ERROR: expected start of statement, got INT token with literal 1
+>> create table a (b int);
+OK
+>> create table b (b int);
+OK
+>> insert into a values (1);
+OK
+>> insert into a values (2);
+OK
+>> insert into b values (1);
+OK
+>> select a.a from a join b on a.b = b.b
+ERROR: no such column: a.a
+>> select a.b from a join b on a.b = b.b
+b
+1
 ```
 
 Based on Thorsten Ball's excellent [Writing an Interpreter in Go](https://interpreterbook.com/).

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -27,11 +27,17 @@ type OrderByExpression struct {
 	Descending bool
 }
 
+type Join struct {
+	Table string
+	On    Expression
+}
+
 type SelectStatement struct {
 	Token       token.Token // the SELECT token
 	Expressions []Expression
 	Aliases     []string // SELECT value AS some_alias
 	From        string
+	Join        *Join
 	OrderBy     []OrderByExpression // can be any expression that would be valid in the query's select list
 	Limit       *int
 	Offset      *int

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -216,9 +216,13 @@ func evalCreateTableStatement(backend Backend, cst *ast.CreateTableStatement) ob
 	columns := make([]object.Column, len(cst.Columns))
 	i := 0
 	for name, typeToken := range cst.Columns {
+		dataType, err := object.DataTypeFromString(typeToken.Literal)
+		if err != nil {
+			return newError(err.Error())
+		}
 		columns[i] = object.Column{
 			Name: name,
-			Type: object.DataType(typeToken.Literal), // This should always be valid since it has parsed successfully
+			Type: dataType,
 		}
 		i++
 	}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -141,7 +141,7 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 			}
 			include, ok := v.(*object.Boolean)
 			if !ok {
-				return newError("argument of WHERE must be type boolean, not type integer: %s", v.Inspect())
+				return newError("argument of WHERE must be type boolean, not %s: %s", v.Type(), v.Inspect())
 			}
 			if !include.Value {
 				continue

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -529,8 +529,9 @@ func TestEvalSelectFrom(t *testing.T) {
 	for _, tt := range tests {
 		backend := newTestBackend()
 		backend.tables["foo"] = []object.Column{
-			{Name: "a", Type: object.DataType("TEXT")},
-			{Name: "b", Type: object.DataType("TEXT")},
+			{Name: "a", Type: object.TEXT},
+			{Name: "b", Type: object.TEXT},
+			{Name: "c", Type: object.INTEGER},
 		}
 		backend.rows["foo"] = []object.Row{
 			{
@@ -539,7 +540,7 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "efg"},
 					&object.Integer{Value: 1},
 				},
-				Aliases: []string{"a", "b"},
+				Aliases: []string{"a", "b", "c"},
 			},
 			{
 				Values: []object.Object{
@@ -547,7 +548,28 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "def"},
 					&object.Integer{Value: 2},
 				},
-				Aliases: []string{"a", "b"},
+				Aliases: []string{"a", "b", "c"},
+			},
+		}
+		// a second table
+		backend.tables["bar"] = []object.Column{
+			{Name: "a", Type: object.TEXT},
+			{Name: "e", Type: object.TEXT},
+		}
+		backend.rows["bar"] = []object.Row{
+			{
+				Values: []object.Object{
+					&object.String{Value: "abc"},
+					&object.String{Value: "10"},
+				},
+				Aliases: []string{"a", "e"},
+			},
+			{
+				Values: []object.Object{
+					&object.String{Value: "bcd"},
+					&object.String{Value: "20"},
+				},
+				Aliases: []string{"a", "e"},
 			},
 		}
 		evaluated := testEval(backend, tt.input)
@@ -569,7 +591,6 @@ func TestEvalSelectFrom(t *testing.T) {
 			t.Fatalf("expected row to contain %d element. got=%d", len(tt.expected[0]), len(row1.Values))
 		}
 		for i := range row1.Values {
-			// log.Println(row1.Values[i])
 			testStringObject(t, row1.Values[i], tt.expected[0][i])
 		}
 		if len(result.Rows) == 1 {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -533,6 +533,14 @@ func TestEvalSelectFrom(t *testing.T) {
 			[][]string{},
 			"b",
 		},
+		{
+			"select a, b, e from foo join bar on foo.a = bar.a",
+			[][]string{
+				{"abc", "efg", "10"},
+				{"bcd", "def", "20"},
+			},
+			"a, b, e",
+		},
 	}
 	for _, tt := range tests {
 		backend := newTestBackend()

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -450,6 +450,14 @@ func TestEvalSelectFrom(t *testing.T) {
 			"a, b",
 		},
 		{
+			"select a, foo.b from foo",
+			[][]string{
+				{"abc", "efg"},
+				{"bcd", "def"},
+			},
+			"a, b",
+		},
+		{
 			"select a from foo",
 			[][]string{
 				{"abc"},
@@ -540,7 +548,8 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "efg"},
 					&object.Integer{Value: 1},
 				},
-				Aliases: []string{"a", "b", "c"},
+				Aliases:      []string{"a", "b", "c"},
+				SourceTables: []string{"foo", "foo", "foo"},
 			},
 			{
 				Values: []object.Object{
@@ -548,7 +557,8 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "def"},
 					&object.Integer{Value: 2},
 				},
-				Aliases: []string{"a", "b", "c"},
+				Aliases:      []string{"a", "b", "c"},
+				SourceTables: []string{"foo", "foo", "foo"},
 			},
 		}
 		// a second table
@@ -562,14 +572,16 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "abc"},
 					&object.String{Value: "10"},
 				},
-				Aliases: []string{"a", "e"},
+				Aliases:      []string{"a", "e"},
+				SourceTables: []string{"bar", "bar"},
 			},
 			{
 				Values: []object.Object{
 					&object.String{Value: "bcd"},
 					&object.String{Value: "20"},
 				},
-				Aliases: []string{"a", "e"},
+				Aliases:      []string{"a", "e"},
+				SourceTables: []string{"bar", "bar"},
 			},
 		}
 		evaluated := testEval(backend, tt.input)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -164,6 +164,12 @@ func (l *Lexer) NextToken() token.Token {
 			if strings.ToUpper(tok.Literal) == token.WHERE {
 				return token.Token{Type: token.WHERE, Literal: token.WHERE}
 			}
+			if strings.ToUpper(tok.Literal) == token.JOIN {
+				return token.Token{Type: token.JOIN, Literal: token.JOIN}
+			}
+			if strings.ToUpper(tok.Literal) == token.ON {
+				return token.Token{Type: token.ON, Literal: token.ON}
+			}
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -209,7 +209,7 @@ func (l *Lexer) readNumber() token.Token {
 
 func (l *Lexer) readIdentifier() token.Token {
 	position := l.position
-	for isLetter(l.ch) || l.ch == '_' {
+	for isLetter(l.ch) || l.ch == '_' || l.ch == '.' {
 		l.readChar()
 	}
 	return token.Token{

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -10,7 +10,7 @@ import (
 func TestExpressionValue(t *testing.T) {
 	input := `
 1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values from identifier_with_underscore;
-order by desc asc false true = != !2 and or limit offset where < <= > >= join on
+order by desc asc false true = != !2 and or limit offset where < <= > >= join on table.identifier
 `
 	tests := []struct {
 		expectedType    token.TokenType
@@ -74,6 +74,7 @@ order by desc asc false true = != !2 and or limit offset where < <= > >= join on
 		{token.GREATERTHANOREQUALS, ">="},
 		{token.JOIN, "JOIN"},
 		{token.ON, "ON"},
+		{token.IDENTIFIER, "table.identifier"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -10,7 +10,7 @@ import (
 func TestExpressionValue(t *testing.T) {
 	input := `
 1 + 2 * (30 / 5) - 1 + 3.14 + 'abc' 1.0 'def' select SELECT SeLeCT aWord , AS as aS As create table text double integer insert into values from identifier_with_underscore;
-order by desc asc false true = != !2 and or limit offset where < <= > >=
+order by desc asc false true = != !2 and or limit offset where < <= > >= join on
 `
 	tests := []struct {
 		expectedType    token.TokenType
@@ -72,6 +72,8 @@ order by desc asc false true = != !2 and or limit offset where < <= > >=
 		{token.LESSTHANOREQUALS, "<="},
 		{token.GREATERTHAN, ">"},
 		{token.GREATERTHANOREQUALS, ">="},
+		{token.JOIN, "JOIN"},
+		{token.ON, "ON"},
 	}
 	l := lexer.New(input)
 	for i, tt := range tests {

--- a/object/object.go
+++ b/object/object.go
@@ -76,7 +76,24 @@ const (
 	TEXT    = "TEXT"
 	INTEGER = "INTEGER"
 	DOUBLE  = "DOUBLE"
+	BOOLEAN = "BOOLEAN"
 )
+
+func DataTypeFromString(dataType string) (DataType, error) {
+	if dataType == TEXT {
+		return TEXT, nil
+	}
+	if dataType == INTEGER {
+		return INTEGER, nil
+	}
+	if dataType == DOUBLE {
+		return DOUBLE, nil
+	}
+	if dataType == BOOLEAN {
+		return BOOLEAN, nil
+	}
+	return "", fmt.Errorf("no such DataType: %s", dataType)
+}
 
 type Table struct {
 	Name    string

--- a/object/object.go
+++ b/object/object.go
@@ -34,6 +34,7 @@ type Row struct {
 	Aliases      []string
 	Values       []Object
 	SortByValues []SortBy
+	SourceTables []string
 }
 
 func (r *Row) Inspect() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -253,6 +253,26 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		p.nextToken()
 	}
 
+	if p.curToken.Type == token.JOIN {
+		p.nextToken()
+		// assert next token is a table name
+		if p.curToken.Type != token.IDENTIFIER {
+			p.errors = append(p.errors, fmt.Sprintf("expected identifier for table to join, got %s token with literal %s", p.curToken.Type, p.curToken.Literal))
+			return nil
+		}
+		table := p.curToken.Literal
+		if !p.expectPeek(token.ON) {
+			return nil
+		}
+		p.nextToken()
+		joinExpr := p.parseExpression(LOWEST)
+		stmt.Join = &ast.Join{
+			Table: table,
+			On:    joinExpr,
+		}
+		p.nextToken()
+	}
+
 	if p.curToken.Type == token.WHERE {
 		p.nextToken()
 		stmt.Where = p.parseExpression(LOWEST)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -444,7 +444,7 @@ func TestStringLiteralExpression(t *testing.T) {
 }
 
 func TestIdentifierExpression(t *testing.T) {
-	input := "select foo"
+	input := "select foo.bar"
 	l := lexer.New(input)
 	p := parser.New(l)
 
@@ -452,6 +452,8 @@ func TestIdentifierExpression(t *testing.T) {
 	if program == nil {
 		t.Fatalf("ParseProgram() returned nil")
 	}
+
+	checkParserErrors(t, p)
 
 	if len(program.Statements) != 1 {
 		t.Fatalf("program.Statements does not contain 1 statements. got=%d", len(program.Statements))
@@ -470,11 +472,10 @@ func TestIdentifierExpression(t *testing.T) {
 	if !ok {
 		t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[0])
 	}
-	expectedLiteral := "foo"
+	expectedLiteral := "foo.bar"
 	if literal.TokenLiteral() != expectedLiteral {
 		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral, literal.TokenLiteral())
 	}
-	checkParserErrors(t, p)
 }
 
 func TestSelectMultiple(t *testing.T) {

--- a/token/token.go
+++ b/token/token.go
@@ -51,6 +51,8 @@ const (
 	LIMIT  = "LIMIT"
 	OFFSET = "OFFSET"
 	WHERE  = "WHERE"
+	JOIN   = "JOIN"
+	ON     = "ON"
 
 	// Types
 	TEXT    = "TEXT"


### PR DESCRIPTION
The code is now getting quite messy. This is more of a "this works" rather than "this is how I want it to look." For example, the `object.Row` struct is doing more work than it should. It is simultaneously functioning as a "row from the backend" and a "evaluated row to display."

But it works! The PR adds support for joining two tables using `select ... from foo join bar on foo.column_x = bar.column_y`. I think the SQL spec allows joining arbitrarily many tables, but that will have to wait!