### PR TITLE
Check table name as well as column name when evaluating identifiers

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -32,7 +32,7 @@ type SelectStatement struct {
 	Expressions []Expression
 	Aliases     []string // SELECT value AS some_alias
 	From        string
-	OrderBy     []OrderByExpression // can be any expression that would be valid in the query's select list
+	OrderBy     []*OrderByExpression // can be any expression that would be valid in the query's select list
 	Limit       *int
 	Offset      *int
 	Where       Expression

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -65,7 +65,7 @@ func evalExpression(row object.Row, node ast.Expression) object.Object {
 	case *ast.Identifier:
 		if row.Values != nil && row.Aliases != nil {
 			for i := range row.Values {
-				if row.Aliases[i] == node.Value {
+				if row.Aliases[i] == node.Value && row.TableName[i] == node.Table {
 					return row.Values[i]
 				}
 			}
@@ -88,7 +88,7 @@ func evalStatements(backend Backend, stmts []ast.Statement) object.Object {
 }
 
 // identifiersInExpression walks the node and returns a slice of all identifiers as strings
-func identifiersInExpression(node ast.Expression) ([]ast.Identifier, error) {
+func identifiersInExpression(node ast.Expression) ([]*ast.Identifier, error) {
 	switch node := node.(type) {
 	case *ast.PrefixExpression:
 		right, err := identifiersInExpression(node.Right)
@@ -105,14 +105,14 @@ func identifiersInExpression(node ast.Expression) ([]ast.Identifier, error) {
 		if err != nil {
 			return nil, err
 		}
-		var identifiers []ast.Identifier
+		var identifiers []*ast.Identifier
 		identifiers = append(identifiers, left...)
 		identifiers = append(identifiers, right...)
 		return identifiers, nil
 	case *ast.IntegerLiteral, *ast.BooleanLiteral, *ast.FloatLiteral, *ast.StringLiteral:
 		return nil, nil
 	case *ast.Identifier:
-		return []ast.Identifier{*node}, nil
+		return []*ast.Identifier{node}, nil
 	}
 	return nil, fmt.Errorf("unknown expression type %T", node)
 }
@@ -129,26 +129,41 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 		}
 	}
 
-	identifiers := make(map[ast.Identifier]bool)
+	var allIdentifiers []*ast.Identifier
 	for _, expr := range ss.Expressions {
 		ids, err := identifiersInExpression(expr)
 		if err != nil {
 			return newError(err.Error())
 		}
-		for _, id := range ids {
-			// identifier is on the form `table_name.column_name`,
-			// but not selecting from `table_name`
-			if id.Table != "" && id.Table != ss.From {
-				return newError(`missing FROM-clause entry for table "%s"`, id.Table)
-			}
-			identifiers[id] = true
+		allIdentifiers = append(allIdentifiers, ids...)
+	}
+	if ss.Where != nil {
+		ids, err := identifiersInExpression(ss.Where)
+		if err != nil {
+			return newError(err.Error())
+		}
+		allIdentifiers = append(allIdentifiers, ids...)
+	}
+	for _, orderBy := range ss.OrderBy {
+		ids, err := identifiersInExpression(orderBy.Expression)
+		if err != nil {
+			return newError(err.Error())
+		}
+		allIdentifiers = append(allIdentifiers, ids...)
+	}
+	for _, id := range allIdentifiers {
+		// identifier is on the form `table_name.column_name`,
+		// but not selecting from `table_name`
+		if id.Table != "" && id.Table != ss.From {
+			return newError(`missing FROM-clause entry for table "%s"`, id.Table)
 		}
 	}
 
-	for identifier := range identifiers {
+	for _, identifier := range allIdentifiers {
 		if !columns[identifier.Value] {
 			return newError("no such column: %s", identifier.Value)
 		}
+		identifier.Table = ss.From
 	}
 
 	// fetch rows if selecting from a table

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -161,7 +161,7 @@ func evalSelectStatement(backend Backend, ss *ast.SelectStatement) object.Object
 
 	for _, identifier := range allIdentifiers {
 		if !columns[identifier.Value] {
-			return newError("no such column: %s", identifier.Value)
+			return newError(`column "%s" does not exist`, identifier.Value)
 		}
 		identifier.Table = ss.From
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -547,8 +547,9 @@ func TestEvalSelectFrom(t *testing.T) {
 	for _, tt := range tests {
 		backend := newTestBackend()
 		backend.tables["foo"] = []object.Column{
-			{Name: "a", Type: object.DataType("TEXT")},
-			{Name: "b", Type: object.DataType("TEXT")},
+			{Name: "a", Type: object.TEXT},
+			{Name: "b", Type: object.TEXT},
+			{Name: "c", Type: object.INTEGER},
 		}
 		backend.rows["foo"] = []object.Row{
 			{

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -214,7 +214,7 @@ func TestEvalIdentifierExpression(t *testing.T) {
 		input                string
 		expectedErrorMessage string
 	}{
-		{"select foo", "no such column: foo"},
+		{"select foo", `column "foo" does not exist`},
 	}
 	for _, tt := range tests {
 		evaluated := testEval(newTestBackend(), tt.input)

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -557,7 +557,8 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "efg"},
 					&object.Integer{Value: 1},
 				},
-				Aliases: []string{"a", "b"},
+				Aliases:   []string{"a", "b", "c"},
+				TableName: []string{"foo", "foo", "foo"},
 			},
 			{
 				Values: []object.Object{
@@ -565,10 +566,11 @@ func TestEvalSelectFrom(t *testing.T) {
 					&object.String{Value: "def"},
 					&object.Integer{Value: 2},
 				},
-				Aliases: []string{"a", "b"},
+				Aliases:   []string{"a", "b", "c"},
+				TableName: []string{"foo", "foo", "foo"},
 			},
 		}
-		backend.columns["foo"] = []string{"a", "b"}
+		backend.columns["foo"] = []string{"a", "b", "c"}
 		evaluated := testEval(backend, tt.input)
 		result, ok := evaluated.(*object.Result)
 		if !ok {
@@ -588,7 +590,6 @@ func TestEvalSelectFrom(t *testing.T) {
 			t.Fatalf("expected row to contain %d element. got=%d", len(tt.expected[0]), len(row1.Values))
 		}
 		for i := range row1.Values {
-			// log.Println(row1.Values[i])
 			testStringObject(t, row1.Values[i], tt.expected[0][i])
 		}
 		if len(result.Rows) == 1 {

--- a/object/object.go
+++ b/object/object.go
@@ -34,6 +34,7 @@ type Row struct {
 	Aliases      []string
 	Values       []Object
 	SortByValues []SortBy
+	TableName    []string
 }
 
 func (r *Row) Inspect() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -208,7 +208,7 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		Expressions: make([]ast.Expression, 0),
 		Aliases:     make([]string, 0),
 		From:        "",
-		OrderBy:     make([]ast.OrderByExpression, 0),
+		OrderBy:     make([]*ast.OrderByExpression, 0),
 		Limit:       nil,
 		Where:       nil,
 	}
@@ -281,7 +281,7 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		if sortExpr == nil {
 			return nil
 		}
-		orderBy := ast.OrderByExpression{Expression: sortExpr}
+		orderBy := &ast.OrderByExpression{Expression: sortExpr}
 		p.nextToken()
 		if p.curToken.Type == token.DESC {
 			orderBy.Descending = true
@@ -296,7 +296,7 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 			if sortExpr == nil {
 				return nil
 			}
-			orderBy := ast.OrderByExpression{Expression: sortExpr}
+			orderBy := &ast.OrderByExpression{Expression: sortExpr}
 			p.nextToken()
 			if p.curToken.Type == token.DESC {
 				orderBy.Descending = true


### PR DESCRIPTION
This meant also changing the identifier walking to return pointers to identifiers, and populating these with the correct table name.