### PR TITLE
Add support for table aliases

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -35,14 +35,15 @@ const (
 )
 
 type Join struct {
-	Table     string
+	With      *From
 	Predicate Expression
 	JoinType  JoinType
 }
 
 type From struct {
-	Table string
-	Join  *Join
+	Table      string
+	TableAlias string
+	Join       *Join
 }
 
 type SelectStatement struct {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -155,11 +155,11 @@ func evalSelectStatement(backend Backend, stmt *ast.SelectStatement) object.Obje
 			columns[c][from.Table] = true
 		}
 		if from.Join != nil {
-			for _, c := range backend.ColumnsInTable(from.Join.Table) {
+			for _, c := range backend.ColumnsInTable(from.Join.With.Table) {
 				if _, ok := columns[c]; !ok {
 					columns[c] = make(map[string]bool)
 				}
-				columns[c][from.Join.Table] = true
+				columns[c][from.Join.With.Table] = true
 			}
 		}
 	}
@@ -208,7 +208,7 @@ func evalSelectStatement(backend Backend, stmt *ast.SelectStatement) object.Obje
 					missingFrom = false
 				}
 				if from.Join != nil {
-					if id.Table == from.Join.Table {
+					if id.Table == from.Join.With.Table {
 						missingFrom = false
 					}
 				}
@@ -255,7 +255,7 @@ func evalSelectStatement(backend Backend, stmt *ast.SelectStatement) object.Obje
 		rows = newRows
 		if from.Join != nil {
 			newRows = []object.Row{}
-			r, err = backend.Rows(from.Join.Table)
+			r, err = backend.Rows(from.Join.With.Table)
 			if err != nil {
 				return newError(err.Error())
 			}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -220,9 +220,10 @@ func evalSelectStatement(backend Backend, stmt *ast.SelectStatement) object.Obje
 					missingFrom = false
 				}
 
-				// alias not provided
+				// alias is provided
 				if from.TableAlias != "" && id.Table == from.TableAlias {
 					missingFrom = false
+					id.Table = from.Table
 				}
 				if from.Join != nil {
 					// alias not provided
@@ -230,9 +231,10 @@ func evalSelectStatement(backend Backend, stmt *ast.SelectStatement) object.Obje
 						missingFrom = false
 					}
 
-					// alias not provided
+					// alias is provided
 					if from.Join.With.TableAlias != "" && id.Table == from.Join.With.TableAlias {
 						missingFrom = false
+						id.Table = from.Join.With.Table
 					}
 				}
 			}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -257,6 +257,7 @@ func TestSelectErrors(t *testing.T) {
 		{"select a from foo, bar", `column reference "a" is ambiguous`},
 		{"select a from foo order by d", `column "d" does not exist`},
 		{"select a from foo where 1", `argument of WHERE must be type boolean, not type integer: 1`},
+		{"select foo.a from foo f where 1", `invalid reference to FROM-clause entry for table "foo". Perhaps you meant to reference the table alias "f"`},
 	}
 	for _, tt := range tests {
 		backend := newTestBackend()

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -655,6 +655,36 @@ func TestEvalSelectFrom(t *testing.T) {
 			"a, a",
 		},
 		{
+			"select f.a, b.a from foo f join bar b on true",
+			[]object.Row{
+				{
+					Values: []object.Object{
+						&object.String{Value: "abc"},
+						&object.String{Value: "m"},
+					},
+				},
+				{
+					Values: []object.Object{
+						&object.String{Value: "abc"},
+						&object.String{Value: "n"},
+					},
+				},
+				{
+					Values: []object.Object{
+						&object.String{Value: "bcd"},
+						&object.String{Value: "m"},
+					},
+				},
+				{
+					Values: []object.Object{
+						&object.String{Value: "bcd"},
+						&object.String{Value: "n"},
+					},
+				},
+			},
+			"a, a",
+		},
+		{
 			"select b from foo order by b",
 			[]object.Row{
 				{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -293,6 +293,12 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		from := &ast.From{Table: p.curToken.Literal}
 		p.nextToken()
 
+		// table alias
+		if p.curToken.Type == token.IDENTIFIER {
+			from.TableAlias = p.curToken.Literal
+			p.nextToken()
+		}
+
 		if p.curToken.Type == token.JOIN {
 			p.nextToken()
 			// assert next token is a table name
@@ -306,11 +312,20 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 			}
 			p.nextToken()
 			joinExpr := p.parseExpression(LOWEST)
+			joinWith := &ast.From{
+				Table: table,
+			}
 			from.Join = &ast.Join{
-				Table:     table,
+				With:      joinWith,
 				Predicate: joinExpr,
+				JoinType:  ast.INNERJOIN,
 			}
 			p.nextToken()
+			// table alias
+			if p.curToken.Type == token.IDENTIFIER {
+				from.Join.With.TableAlias = p.curToken.Literal
+				p.nextToken()
+			}
 		}
 		stmt.From = append(stmt.From, from)
 	}
@@ -324,6 +339,11 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 		}
 		from := &ast.From{Table: p.curToken.Literal}
 		p.nextToken()
+		// table alias
+		if p.curToken.Type == token.IDENTIFIER {
+			from.TableAlias = p.curToken.Literal
+			p.nextToken()
+		}
 
 		if p.curToken.Type == token.JOIN {
 			p.nextToken()
@@ -338,12 +358,20 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 			}
 			p.nextToken()
 			joinExpr := p.parseExpression(LOWEST)
+			joinWith := &ast.From{
+				Table: table,
+			}
 			from.Join = &ast.Join{
-				Table:     table,
+				With:      joinWith,
 				Predicate: joinExpr,
 				JoinType:  ast.INNERJOIN,
 			}
 			p.nextToken()
+			// table alias
+			if p.curToken.Type == token.IDENTIFIER {
+				from.Join.With.TableAlias = p.curToken.Literal
+				p.nextToken()
+			}
 		}
 		stmt.From = append(stmt.From, from)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -306,15 +306,20 @@ func (p *Parser) parseSelectStatement() ast.Statement {
 				p.errors = append(p.errors, fmt.Sprintf("expected identifier for table to join, got %s token with literal %s", p.curToken.Type, p.curToken.Literal))
 				return nil
 			}
-			table := p.curToken.Literal
+			joinWith := &ast.From{
+				Table: p.curToken.Literal,
+			}
+			// table alias
+			if p.peekToken.Type == token.IDENTIFIER {
+				joinWith.TableAlias = p.peekToken.Literal
+				p.nextToken()
+			}
+
 			if !p.expectPeek(token.ON) {
 				return nil
 			}
 			p.nextToken()
 			joinExpr := p.parseExpression(LOWEST)
-			joinWith := &ast.From{
-				Table: table,
-			}
 			from.Join = &ast.Join{
 				With:      joinWith,
 				Predicate: joinExpr,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1190,7 +1190,7 @@ func TestParseMultipleStatementsError(t *testing.T) {
 }
 
 func TestSelectJoin(t *testing.T) {
-	input := "select a from foo join bar on foo.a = bar.b, baz join qux on x = y"
+	input := "select a from foo f join bar b on f.a = b.b, baz join qux on x = y"
 	l := lexer.New(input)
 	p := parser.New(l)
 
@@ -1232,12 +1232,21 @@ func TestSelectJoin(t *testing.T) {
 	if stmt.From[0].Table != expectedFrom1 {
 		t.Fatalf("stmt.From[0].Table not %s. got=%s", expectedFrom1, stmt.From[0].Table)
 	}
+	expectedFromAlias1 := "f"
+	if stmt.From[0].TableAlias != expectedFromAlias1 {
+		t.Fatalf("stmt.From[0].TableAlias not %s. got=%s", expectedFromAlias1, stmt.From[0].TableAlias)
+	}
+
 	if stmt.From[0].Join == nil {
 		t.Fatalf("stmt.From[0].Join is nil")
 	}
 	expectedJoinTable1 := "bar"
 	if stmt.From[0].Join.With.Table != expectedJoinTable1 {
-		t.Fatalf("stmt.From[0].Join.Table is not %s. got=%s", expectedJoinTable1, stmt.From[0].Join.With.Table)
+		t.Fatalf("stmt.From[0].Join.With.Table is not %s. got=%s", expectedJoinTable1, stmt.From[0].Join.With.Table)
+	}
+	expectedJoinAlias1 := "b"
+	if stmt.From[0].Join.With.TableAlias != expectedJoinAlias1 {
+		t.Fatalf("stmt.From[0].Join.With.TableAlias not %s. got=%s", expectedJoinAlias1, stmt.From[0].Join.With.TableAlias)
 	}
 	expectedJoinPred1 := "(a = b)"
 	if stmt.From[0].Join.Predicate.String() != expectedJoinPred1 {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -591,77 +591,90 @@ func TestQualifiedIdentifier(t *testing.T) {
 }
 
 func TestSelectCartesianJoin(t *testing.T) {
-	input := "select a.a, b.b from a, b"
-	l := lexer.New(input)
-	p := parser.New(l)
+	tt := []string{
+		"select f.a, b.b from foo f, bar b",
+	}
+	for _, input := range tt {
+		l := lexer.New(input)
+		p := parser.New(l)
 
-	program := p.ParseProgram()
-	if program == nil {
-		t.Fatalf("ParseProgram() returned nil")
-	}
+		program := p.ParseProgram()
+		if program == nil {
+			t.Fatalf("ParseProgram() returned nil")
+		}
 
-	if len(program.Statements) != 1 {
-		t.Fatalf("program.Statements does not contain 1 statements. got=%d", len(program.Statements))
-	}
+		checkParserErrors(t, p)
 
-	stmt, ok := program.Statements[0].(*ast.SelectStatement)
-	if !ok {
-		t.Fatalf("program.Statements[0] is not ast.SelectStatement. got=%T", program.Statements[0])
-	}
+		if len(program.Statements) != 1 {
+			t.Fatalf("program.Statements does not contain 1 statements. got=%d", len(program.Statements))
+		}
 
-	if len(stmt.Expressions) != 2 {
-		t.Fatalf("stmt does not contain %d expressions. got=%d", 1, len(stmt.Expressions))
-	}
+		stmt, ok := program.Statements[0].(*ast.SelectStatement)
+		if !ok {
+			t.Fatalf("program.Statements[0] is not ast.SelectStatement. got=%T", program.Statements[0])
+		}
 
-	literal1, ok := stmt.Expressions[0].(*ast.Identifier)
-	if !ok {
-		t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[0])
-	}
-	expectedLiteral1 := "a.a"
-	if literal1.TokenLiteral() != expectedLiteral1 {
-		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral1, literal1.TokenLiteral())
-	}
-	expectedTable1 := "a"
-	if literal1.Table != expectedTable1 {
-		t.Errorf("literal.Table not %s. got=%s", expectedTable1, literal1.Table)
-	}
-	expectedValue1 := "a"
-	if literal1.Value != expectedValue1 {
-		t.Errorf("literal.Value not %s. got=%s", expectedValue1, literal1.Value)
-	}
+		if len(stmt.Expressions) != 2 {
+			t.Fatalf("stmt does not contain %d expressions. got=%d", 1, len(stmt.Expressions))
+		}
 
-	literal2, ok := stmt.Expressions[1].(*ast.Identifier)
-	if !ok {
-		t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[1])
-	}
-	expectedLiteral2 := "b.b"
-	if literal2.TokenLiteral() != expectedLiteral2 {
-		t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral2, literal2.TokenLiteral())
-	}
-	expectedTable2 := "b"
-	if literal2.Table != expectedTable2 {
-		t.Errorf("literal.Table not %s. got=%s", expectedTable2, literal2.Table)
-	}
-	expectedValue2 := "b"
-	if literal2.Value != expectedValue2 {
-		t.Errorf("literal.Value not %s. got=%s", expectedValue2, literal2.Value)
-	}
+		literal1, ok := stmt.Expressions[0].(*ast.Identifier)
+		if !ok {
+			t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[0])
+		}
+		expectedLiteral1 := "f.a"
+		if literal1.TokenLiteral() != expectedLiteral1 {
+			t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral1, literal1.TokenLiteral())
+		}
+		expectedTable1 := "f"
+		if literal1.Table != expectedTable1 {
+			t.Errorf("literal.Table not %s. got=%s", expectedTable1, literal1.Table)
+		}
+		expectedValue1 := "a"
+		if literal1.Value != expectedValue1 {
+			t.Errorf("literal.Value not %s. got=%s", expectedValue1, literal1.Value)
+		}
 
-	expectedFromLen := 2
-	if len(stmt.From) != expectedFromLen {
-		t.Fatalf("stmt.From not length %d. got=%d", expectedFromLen, len(stmt.From))
-	}
+		literal2, ok := stmt.Expressions[1].(*ast.Identifier)
+		if !ok {
+			t.Fatalf("exp not *ast.Identifier. got=%T", stmt.Expressions[1])
+		}
+		expectedLiteral2 := "b.b"
+		if literal2.TokenLiteral() != expectedLiteral2 {
+			t.Errorf("literal.TokenLiteral not %s. got=%s", expectedLiteral2, literal2.TokenLiteral())
+		}
+		expectedTable2 := "b"
+		if literal2.Table != expectedTable2 {
+			t.Errorf("literal.Table not %s. got=%s", expectedTable2, literal2.Table)
+		}
+		expectedValue2 := "b"
+		if literal2.Value != expectedValue2 {
+			t.Errorf("literal.Value not %s. got=%s", expectedValue2, literal2.Value)
+		}
 
-	expectedFrom1 := "a"
-	if stmt.From[0].Table != expectedFrom1 {
-		t.Fatalf("stmt.From[0] not %s. got=%s", expectedFrom1, stmt.From[0].Table)
-	}
-	expectedFrom2 := "b"
-	if stmt.From[1].Table != expectedFrom2 {
-		t.Fatalf("stmt.From[1] not %s. got=%s", expectedFrom2, stmt.From[1].Table)
-	}
+		expectedFromLen := 2
+		if len(stmt.From) != expectedFromLen {
+			t.Fatalf("stmt.From not length %d. got=%d", expectedFromLen, len(stmt.From))
+		}
 
-	checkParserErrors(t, p)
+		expectedFrom1 := "foo"
+		if stmt.From[0].Table != expectedFrom1 {
+			t.Fatalf("stmt.From[0] not %s. got=%s", expectedFrom1, stmt.From[0].Table)
+		}
+		expectedFromAlias1 := "f"
+		if stmt.From[0].TableAlias != expectedFromAlias1 {
+			t.Fatalf("stmt.FromAlias[0] not %s. got=%s", expectedFromAlias1, stmt.From[0].Table)
+		}
+
+		expectedFrom2 := "bar"
+		if stmt.From[1].Table != expectedFrom2 {
+			t.Fatalf("stmt.From[1] not %s. got=%s", expectedFrom2, stmt.From[1].Table)
+		}
+		expectedFromAlias2 := "b"
+		if stmt.From[1].TableAlias != expectedFromAlias2 {
+			t.Fatalf("stmt.FromAlias[1] not %s. got=%s", expectedFromAlias2, stmt.From[1].Table)
+		}
+	}
 }
 
 func TestSelectMultiple(t *testing.T) {
@@ -1223,8 +1236,8 @@ func TestSelectJoin(t *testing.T) {
 		t.Fatalf("stmt.From[0].Join is nil")
 	}
 	expectedJoinTable1 := "bar"
-	if stmt.From[0].Join.Table != expectedJoinTable1 {
-		t.Fatalf("stmt.From[0].Join.Table is not %s. got=%s", expectedJoinTable1, stmt.From[0].Join.Table)
+	if stmt.From[0].Join.With.Table != expectedJoinTable1 {
+		t.Fatalf("stmt.From[0].Join.Table is not %s. got=%s", expectedJoinTable1, stmt.From[0].Join.With.Table)
 	}
 	expectedJoinPred1 := "(a = b)"
 	if stmt.From[0].Join.Predicate.String() != expectedJoinPred1 {
@@ -1239,8 +1252,8 @@ func TestSelectJoin(t *testing.T) {
 		t.Fatalf("stmt.From[1].Join is nil")
 	}
 	expectedJoinTable2 := "qux"
-	if stmt.From[1].Join.Table != expectedJoinTable2 {
-		t.Fatalf("stmt.From[1].Join.Table is not %s. got=%s", expectedJoinTable2, stmt.From[1].Join.Table)
+	if stmt.From[1].Join.With.Table != expectedJoinTable2 {
+		t.Fatalf("stmt.From[1].Join.Table is not %s. got=%s", expectedJoinTable2, stmt.From[1].Join.With.Table)
 	}
 	expectedJoinPred2 := "(x = y)"
 	if stmt.From[1].Join.Predicate.String() != expectedJoinPred2 {


### PR DESCRIPTION
- Support queries such as `select f.a from foo f`
- Using the original table name when providing an alias will fail: `select foo.a from foo f`