### PR TITLE
Allow arbitrary number of joins

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -778,6 +778,44 @@ func TestEvalSelectFrom(t *testing.T) {
 			"a, a, c",
 		},
 		{
+			"select f.a, b.a, c, x from bar b join foo f on true join baz on true",
+			[]object.Row{
+				{
+					Values: []object.Object{
+						&object.String{Value: "abc"},
+						&object.String{Value: "m"},
+						&object.String{Value: "1"},
+						&object.String{Value: "x"},
+					},
+				},
+				{
+					Values: []object.Object{
+						&object.String{Value: "bcd"},
+						&object.String{Value: "m"},
+						&object.String{Value: "2"},
+						&object.String{Value: "x"},
+					},
+				},
+				{
+					Values: []object.Object{
+						&object.String{Value: "abc"},
+						&object.String{Value: "n"},
+						&object.String{Value: "1"},
+						&object.String{Value: "x"},
+					},
+				},
+				{
+					Values: []object.Object{
+						&object.String{Value: "bcd"},
+						&object.String{Value: "n"},
+						&object.String{Value: "2"},
+						&object.String{Value: "x"},
+					},
+				},
+			},
+			"a, a, c, x",
+		},
+		{
 			"select f.a, b.a, c from bar b, foo f",
 			[]object.Row{
 				{
@@ -960,6 +998,21 @@ func TestEvalSelectFrom(t *testing.T) {
 			},
 		}
 		backend.columns["bar"] = []string{"a"}
+
+		// table `baz`
+		backend.tables["baz"] = []object.Column{
+			{Name: "x", Type: object.STRING},
+		}
+		backend.rows["baz"] = []object.Row{
+			{
+				Values: []object.Object{
+					&object.String{Value: "x"},
+				},
+				Aliases:   []string{"x"},
+				TableName: []string{"baz"},
+			},
+		}
+		backend.columns["baz"] = []string{"x"}
 
 		evaluated := testEval(backend, tt.input)
 		result, ok := evaluated.(*object.Result)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -272,6 +272,13 @@ func (p *Parser) parseJoin() *ast.Join {
 		p.nextToken()
 		join.With.TableAlias = p.curToken.Literal
 	}
+	if p.peekToken.Type == token.JOIN {
+		join := p.parseJoin()
+		if join == nil {
+			return nil
+		}
+		joinWith.Join = join
+	}
 	return join
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1278,7 +1278,7 @@ func TestParseMultipleStatementsError(t *testing.T) {
 }
 
 func TestSelectJoin(t *testing.T) {
-	input := "select f.a, z.x + q.y from foo f join bar b on f.a = b.b, baz z join qux q on x = y"
+	input := "select f.a, z.x + q.y from foo f join bar b on f.a = b.b, baz z join qux q on x = y join wut on true join aagh on false"
 	l := lexer.New(input)
 	p := parser.New(l)
 
@@ -1365,5 +1365,24 @@ func TestSelectJoin(t *testing.T) {
 	expectedJoinPred2 := "(x = y)"
 	if stmt.From[1].Join.Predicate.String() != expectedJoinPred2 {
 		t.Fatalf("stmt.From[1].Join.Predicate is not %s. got=%s", expectedJoinPred2, stmt.From[1].Join.Predicate)
+	}
+	if stmt.From[1].Join.With.Join == nil {
+		t.Fatalf("stmt.From[1].Join.With.Join is nil")
+	}
+	expectedJoinTable3 := "wut"
+	if stmt.From[1].Join.With.Join.With.Table != expectedJoinTable3 {
+		t.Fatalf("stmt.From[1].Join.With.Join.With.Table is not %s. got=%s", expectedJoinTable3, stmt.From[1].Join.With.Join.With.Table)
+	}
+	expectedJoinPred3 := "TRUE"
+	if stmt.From[1].Join.With.Join.Predicate.String() != expectedJoinPred3 {
+		t.Fatalf("stmt.From[1].Join.With.Join.Predicate is not %s. got=%s", expectedJoinPred3, stmt.From[1].Join.With.Join.Predicate)
+	}
+	expectedJoinTable4 := "aagh"
+	if stmt.From[1].Join.With.Join.With.Join.With.Table != expectedJoinTable4 {
+		t.Fatalf("stmt.From[1].Join.With.Join.With.Join.With.Table is not %s. got=%s", expectedJoinTable4, stmt.From[1].Join.With.Join.With.Join.With.Table)
+	}
+	expectedJoinPred4 := "FALSE"
+	if stmt.From[1].Join.With.Join.With.Join.Predicate.String() != expectedJoinPred4 {
+		t.Fatalf("stmt.From[1].Join.With.Join.With.Join.Predicate is not %s. got=%s", expectedJoinPred4, stmt.From[1].Join.With.Join.With.Join.Predicate)
 	}
 }


### PR DESCRIPTION
Before this only one join allowed, e.g. `select ... from x join y on ...`, but now

`select ... from x join y on ... join z on ...` and even `select ... from x join y on ... join z on ... join m on ...` works.